### PR TITLE
Add strategy comparison feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS Instructions
+
+These are the coding guidelines for this project. All contributors and assistants should apply these rules when editing code or documentation.
+
+1. **Python Style**
+   - Target Python 3.10 or later.
+   - Use descriptive variable and function names.
+   - Include docstrings for all public functions and classes.
+   - Prefer list comprehensions and generator expressions where appropriate.
+
+2. **Error Handling**
+   - Avoid bare `except:` statements. Catch specific exceptions.
+   - Do not suppress errors silently. Log or surface them as needed.
+
+3. **Formatting**
+   - Use Unix (LF) line endings for all files.
+   - End each file with a single newline character.
+   - Keep lines under 79 characters when practical.
+
+4. **Documentation**
+   - Update the README with any new dependencies or setup steps.
+   - Comment complex logic in both Python and JavaScript files.
+
+5. **Testing**
+   - Run `python -m py_compile` on modified Python files to check syntax.
+   - If tests exist, run them before committing changes.
+
+These rules should be consulted before any code changes are proposed or implemented.
+
+6. **Assistant Response Rules**
+   - Provide a Chain-Of-Thought analysis before answering.
+   - Review the attached files thoroughly. If something is missing, ask for it.
+   - If unsure about any aspect of the task, request clarification. Do not guess.
+   - Do nothing unless explicitly instructed. Avoid extra actions.
+   - Preserve all original content except for updated sections.
+   - Write code in full with no placeholders. Ask to continue if output is cut off.
+   - Preserve all existing functionality. Do not modify UI elements unless requested.

--- a/static/style.css
+++ b/static/style.css
@@ -719,6 +719,15 @@ canvas#gantt-canvas {
     overflow-y: visible; /* Ensure vertical content isn’t clipped */
 }
 
+#chart-summary {
+    margin-top: 10px;
+    padding: 8px;
+    font-size: 14px;
+    background: #f9f9f9;
+    border: 1px solid #ccc;
+    max-width: 800px;
+}
+
 
 .gantt-bar {
     position: absolute;
@@ -978,3 +987,21 @@ canvas#gantt-canvas {
     padding: 0 4px;
 }
 .day-cell { position: relative; }
+
+#strategy-comparison {
+    margin-top: 20px;
+    max-width: 800px;
+}
+
+#comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#comparison-table th,
+#comparison-table td {
+    padding: 8px;
+    border: 1px solid #ccc;
+    text-align: left;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -160,7 +160,21 @@
         <div id="optimization-result" style="display: none;">
             <h3>Optimerat schema för föräldraledighet</h3>
             <div id="gantt-chart"></div>
-        <div id="calendar-container"  style="display: none;"> 
+            <div id="strategy-comparison" style="display: none;">
+                <h3>Strategijämförelse</h3>
+                <table id="comparison-table">
+                    <thead>
+                        <tr>
+                            <th>Strategi</th>
+                            <th>Förälder 1</th>
+                            <th>Förälder 2</th>
+                            <th>Genomsnittlig inkomst/månad</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        <div id="calendar-container"  style="display: none;">
 
                 <div class="blocks-container">
                     <h3>Disponibla Veckoblock</h3>


### PR DESCRIPTION
## Summary
- add summary table to compare strategies in *index.html*
- style comparison table in CSS
- extend calculation utilities with average income and together strategy
- compute and display strategy summaries in *index.js*

## Testing
- `python -m py_compile app.py`
- `node --check static/index.js`
- `node --check static/calculations.js`
- `node --check static/chart.js`

------
https://chatgpt.com/codex/tasks/task_e_6845da9dc120832ba8dd697d587af172