### PR TITLE
Fix info-box toggle duplication

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -56,24 +56,24 @@ function setupToggleButtons(groupId, inputId, callback = null) {
     });
 }
 
+function handleInfoBoxClick(e) {
+    const header = e.target.closest('.info-header');
+    if (header) {
+        const box = header.closest('.info-box');
+        const content = header.nextElementSibling;
+        const arrow = header.querySelector('.info-arrow');
+        if (box && content && arrow) {
+            box.classList.toggle('open');
+            content.classList.toggle('open');
+            arrow.classList.toggle('open');
+        }
+    }
+}
+
 function setupInfoBoxToggle() {
     // Remove existing listener to prevent duplicates
     document.removeEventListener('click', handleInfoBoxClick);
     document.addEventListener('click', handleInfoBoxClick);
-
-    function handleInfoBoxClick(e) {
-        const header = e.target.closest('.info-header');
-        if (header) {
-            const box = header.closest('.info-box');
-            const content = header.nextElementSibling;
-            const arrow = header.querySelector('.info-arrow');
-            if (box && content && arrow) {
-                box.classList.toggle('open');
-                content.classList.toggle('open');
-                arrow.classList.toggle('open');
-            }
-        }
-    }
 }
 
 function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, tillägg = 0) {

--- a/static/ui.js
+++ b/static/ui.js
@@ -42,17 +42,17 @@ export function setupToggleButtons(groupId, inputId, callback = null) {
 /**
  * Set up toggle for info boxes
  */
+function toggleInfoBox(e) {
+    const box = e.currentTarget.closest('.info-box');
+    if (box) box.classList.toggle('open');
+}
+
 export function setupInfoBoxToggle() {
     const infoHeaders = document.querySelectorAll('.info-header');
     infoHeaders.forEach(header => {
         header.removeEventListener('click', toggleInfoBox);
         header.addEventListener('click', toggleInfoBox);
     });
-
-    function toggleInfoBox(e) {
-        const box = e.currentTarget.closest('.info-box');
-        if (box) box.classList.toggle('open');
-    }
 }
 
 /**

--- a/templates/script.js
+++ b/templates/script.js
@@ -56,24 +56,24 @@ function setupToggleButtons(groupId, inputId, callback = null) {
     });
 }
 
+function handleInfoBoxClick(e) {
+    const header = e.target.closest('.info-header');
+    if (header) {
+        const box = header.closest('.info-box');
+        const content = header.nextElementSibling;
+        const arrow = header.querySelector('.info-arrow');
+        if (box && content && arrow) {
+            box.classList.toggle('open');
+            content.classList.toggle('open');
+            arrow.classList.toggle('open');
+        }
+    }
+}
+
 function setupInfoBoxToggle() {
     // Remove existing listener to prevent duplicates
     document.removeEventListener('click', handleInfoBoxClick);
     document.addEventListener('click', handleInfoBoxClick);
-
-    function handleInfoBoxClick(e) {
-        const header = e.target.closest('.info-header');
-        if (header) {
-            const box = header.closest('.info-box');
-            const content = header.nextElementSibling;
-            const arrow = header.querySelector('.info-arrow');
-            if (box && content && arrow) {
-                box.classList.toggle('open');
-                content.classList.toggle('open');
-                arrow.classList.toggle('open');
-            }
-        }
-    }
 }
 
 function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, tillägg = 0) {

--- a/templates/ui.js
+++ b/templates/ui.js
@@ -42,17 +42,17 @@ export function setupToggleButtons(groupId, inputId, callback = null) {
 /**
  * Set up toggle for info boxes
  */
+function toggleInfoBox(e) {
+    const box = e.currentTarget.closest('.info-box');
+    if (box) box.classList.toggle('open');
+}
+
 export function setupInfoBoxToggle() {
     const infoHeaders = document.querySelectorAll('.info-header');
     infoHeaders.forEach(header => {
         header.removeEventListener('click', toggleInfoBox);
         header.addEventListener('click', toggleInfoBox);
     });
-
-    function toggleInfoBox(e) {
-        const box = e.currentTarget.closest('.info-box');
-        if (box) box.classList.toggle('open');
-    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Prevent duplicate event listeners on info-box headers
- Ensure info boxes like "Typiska hushållsutgifter i Sverige" toggle correctly

## Testing
- `node --check templates/ui.js static/ui.js templates/script.js static/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68af6833dc0c832b8c8911b840ac04aa