### PR TITLE
Add step-by-step wizard for form questions

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -8,9 +8,9 @@ import {
     förälder1InkomstDagar, förälder2InkomstDagar, förälder1MinDagar, förälder2MinDagar
 } from './config.js';
 import { beräknaDaglig, beräknaBarnbidrag, optimizeParentalLeave } from './calculations.js';
-import { 
-    updateProgress, setupToggleButtons, setupInfoBoxToggle, 
-    generateParentSection, setupStrategyToggle, updateMonthlyBox 
+import {
+    updateProgress, setupInfoBoxToggle,
+    generateParentSection, setupStrategyToggle, updateMonthlyBox
 } from './ui.js';
 import { renderGanttChart } from './chart.js';
 
@@ -25,28 +25,11 @@ document.addEventListener('DOMContentLoaded', () => {
  * Initialize form elements and UI
  */
 function initializeForm() {
-    // Set default active buttons
-    const vårdnadGroup = document.querySelectorAll('#vårdnad-group .toggle-btn');
-    vårdnadGroup.forEach(btn => {
-        if (btn.dataset.value === 'gemensam') {
-            btn.classList.add('active');
-            document.getElementById('vårdnad').value = 'gemensam';
-        }
-    });
-
     // Initialize progress bar
     updateProgress(1);
 
-    // Setup toggle buttons for all groups
-    setupToggleButtons('vårdnad-group', 'vårdnad', handleVårdnadChange);
-    setupToggleButtons('partner-group', 'beräkna-partner', handlePartnerChange);
-    setupToggleButtons('barn-tidigare-group', 'barn-tidigare', () => updateProgress(4));
-    setupToggleButtons('barn-planerade-group', 'barn-planerade', () => updateProgress(5));
-    setupToggleButtons('avtal-group-1', 'har-avtal-1');
-    setupToggleButtons('avtal-group-2', 'har-avtal-2');
+    // Setup strategy and info boxes
     setupStrategyToggle();
-
-    // Setup info box toggles
     setupInfoBoxToggle();
 }
 
@@ -56,8 +39,6 @@ function initializeForm() {
 function setupEventListeners() {
     const form = document.getElementById('calc-form');
     const optimizeBtn = document.getElementById('optimize-btn');
-    const inkomst1Input = document.getElementById('inkomst1');
-    const inkomst2Input = document.getElementById('inkomst2');
 
     // Form submission
     form.addEventListener('submit', handleFormSubmit);
@@ -65,88 +46,10 @@ function setupEventListeners() {
     // Optimization button
     optimizeBtn.addEventListener('click', handleOptimize);
 
-    // Income input listeners
-    inkomst1Input.addEventListener('input', handleInkomst1Change);
-    inkomst2Input.addEventListener('input', handleInkomst2Change);
-
     // Dropdown listeners for uttag
     setupDropdownListeners();
 }
 
-/**
- * Handle vårdnad change
- * @param {string} value - Selected vårdnad value
- */
-function handleVårdnadChange(value) {
-    const partnerQuestion = document.getElementById('partner-question');
-    const inkomstBlock2 = document.getElementById('inkomst-block-2');
-    const avtalQuestion2 = document.getElementById('avtal-question-2');
-    const partnerLedigTid = document.getElementById('partner-ledig-tid');
-    const step6 = document.querySelector('.step-6');
-
-    if (value === 'ensam') {
-        partnerQuestion.style.display = 'none';
-        inkomstBlock2.style.display = 'none';
-        avtalQuestion2.style.display = 'none';
-        partnerLedigTid.style.display = 'none';
-        document.getElementById('beräkna-partner').value = 'nej';
-        if (step6) step6.style.display = 'none';
-        updateProgress(3); // Skip partner question
-    } else {
-        partnerQuestion.style.display = 'block';
-        if (step6) step6.style.display = 'block';
-        updateProgress(2);
-    }
-}
-
-
-/**
- * Handle partner calculation change
- * @param {string} value - Selected partner calculation value
- */
-function handlePartnerChange(value) {
-    const inkomstBlock2 = document.getElementById('inkomst-block-2');
-    const avtalQuestion2 = document.getElementById('avtal-question-2');
-    const parentLedigTid = document.getElementById('parent-ledig-tid'); // Fixed ID
-
-    if (value === 'ja') {
-        inkomstBlock2.style.display = 'block';
-        avtalQuestion2.style.display = 'block';
-        parentLedigTid.style.display = 'block';
-    } else {
-        inkomstBlock2.style.display = 'none';
-        avtalQuestion2.style.display = 'none';
-        parentLedigTid.style.display = 'none';
-    }
-
-    updateProgress(3);
-}
-
-/**
- * Handle first income field change
- */
-function handleInkomst1Change() {
-    const inkomst1 = document.getElementById('inkomst1').value;
-    if (inkomst1 !== '') {
-        const vårdnadValue = document.getElementById('vårdnad').value;
-        const partnerValue = document.getElementById('beräkna-partner').value;
-        if (vårdnadValue === 'gemensam' && partnerValue === 'ja') {
-            updateProgress(6);
-        } else {
-            updateProgress(7);
-        }
-    }
-}
-
-/**
- * Handle second income field change
- */
-function handleInkomst2Change() {
-    const inkomst2 = document.getElementById('inkomst2').value;
-    if (inkomst2 !== '') {
-        updateProgress(7);
-    }
-}
 
 /**
  * Handle form submission

--- a/static/style.css
+++ b/static/style.css
@@ -978,3 +978,19 @@ canvas#gantt-canvas {
     padding: 0 4px;
 }
 .day-cell { position: relative; }
+
+.wizard-step {
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+    transition: opacity 0.4s ease, max-height 0.4s ease;
+}
+
+.wizard-step.visible {
+    opacity: 1;
+    max-height: 1000px;
+}
+
+.hidden {
+    display: none;
+}

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -1,0 +1,99 @@
+import { updateProgress, setupToggleButtons } from './ui.js';
+
+/**
+ * wizard.js - Sequential question wizard for the Föräldrapenningkalkylator
+ * Presents one question at a time and updates the progress bar accordingly.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    const sections = {
+        vardnad: document.querySelector('#vårdnad-group').closest('.wizard-step'),
+        partner: document.getElementById('partner-question'),
+        barnIdag: document.querySelector('#barn-tidigare-group').closest('.wizard-step'),
+        barnPlan: document.querySelector('#barn-planerade-group').closest('.wizard-step'),
+        inkomst1: document.getElementById('inkomst1').closest('.wizard-step'),
+        avtal1: document.getElementById('avtal-question-1'),
+        inkomst2: document.getElementById('inkomst-block-2'),
+        avtal2: document.getElementById('avtal-question-2')
+    };
+    const calculateBtn = document.getElementById('calculate-btn');
+    const step6 = document.querySelector('.step-6');
+    let partnerSelected = false;
+
+    // Hide all wizard steps initially
+    Object.values(sections).forEach(sec => sec?.classList.remove('visible'));
+    calculateBtn.classList.add('hidden');
+
+    // Show first question
+    sections.vardnad?.classList.add('visible');
+    updateProgress(1);
+
+    setupToggleButtons('vårdnad-group', 'vårdnad', value => {
+        sections.vardnad.classList.remove('visible');
+        if (value === 'ensam') {
+            partnerSelected = false;
+            document.getElementById('beräkna-partner').value = 'nej';
+            step6?.style.setProperty('display', 'none');
+            updateProgress(3);
+            sections.barnIdag.classList.add('visible');
+        } else {
+            step6?.style.setProperty('display', 'block');
+            updateProgress(2);
+            sections.partner.classList.add('visible');
+        }
+    });
+
+    setupToggleButtons('partner-group', 'beräkna-partner', value => {
+        partnerSelected = value === 'ja';
+        if (!partnerSelected) step6?.style.setProperty('display', 'none');
+        sections.partner.classList.remove('visible');
+        updateProgress(3);
+        sections.barnIdag.classList.add('visible');
+    });
+
+    setupToggleButtons('barn-tidigare-group', 'barn-tidigare', () => {
+        sections.barnIdag.classList.remove('visible');
+        updateProgress(4);
+        sections.barnPlan.classList.add('visible');
+    });
+
+    setupToggleButtons('barn-planerade-group', 'barn-planerade', () => {
+        sections.barnPlan.classList.remove('visible');
+        updateProgress(5);
+        sections.inkomst1.classList.add('visible');
+    });
+
+    const inkomst1Input = document.getElementById('inkomst1');
+    inkomst1Input.addEventListener('input', () => {
+        if (inkomst1Input.value !== '') {
+            sections.inkomst1.classList.remove('visible');
+            sections.avtal1.classList.add('visible');
+        }
+    });
+
+    setupToggleButtons('avtal-group-1', 'har-avtal-1', () => {
+        sections.avtal1.classList.remove('visible');
+        if (partnerSelected) {
+            updateProgress(6);
+            sections.inkomst2.classList.add('visible');
+        } else {
+            updateProgress(7);
+            calculateBtn.classList.remove('hidden');
+        }
+    });
+
+    const inkomst2Input = document.getElementById('inkomst2');
+    inkomst2Input.addEventListener('input', () => {
+        if (inkomst2Input.value !== '') {
+            sections.inkomst2.classList.remove('visible');
+            sections.avtal2.classList.add('visible');
+        }
+    });
+
+    setupToggleButtons('avtal-group-2', 'har-avtal-2', () => {
+        sections.avtal2.classList.remove('visible');
+        updateProgress(7);
+        calculateBtn.classList.remove('hidden');
+    });
+});
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
         <h1>Föräldrapenningkalkylator</h1>
         
         <form id="calc-form">
-            <div class="form-section">
+            <div class="form-section wizard-step">
                 <label for="vårdnad">Har du Gemensam eller Ensam vårdnad?</label>
                 <div class="button-group" id="vårdnad-group">
                     <button type="button" class="vårdnad-btn toggle-btn" data-value="gemensam">Gemensam vårdnad</button>
@@ -36,7 +36,7 @@
                 <p id="vårdnad-info" class="info-text"></p>
             </div>
 
-            <div id="partner-question" style="display:none;" class="form-section">
+            <div id="partner-question" class="form-section wizard-step">
                 <label for="beräkna-partner">Vill du beräkna föräldrapenning för din partner också?</label>
                 <div class="button-group" id="partner-group">
                     <button type="button" class="toggle-btn" data-value="ja">Ja</button>
@@ -45,7 +45,7 @@
                 <input type="hidden" name="beräkna_partner" id="beräkna-partner" value="">
             </div>
 
-            <div class="form-section">
+            <div class="form-section wizard-step">
                 <label>Hur många barn har du/ni sedan tidigare?</label>
                 <div class="button-group barnval" id="barn-tidigare-group">
                     <button type="button" class="toggle-btn" data-value="0">0</button>
@@ -59,7 +59,7 @@
                 <input type="hidden" id="barn-tidigare" value="0">
             </div>
               
-            <div class="form-section">
+            <div class="form-section wizard-step">
                 <label>Hur många fler barn planerar du/ni att få?</label>
                 <div class="button-group barnval" id="barn-planerade-group">
                     <button type="button" class="toggle-btn" data-value="1">1</button>
@@ -75,11 +75,11 @@
                 Vänligen välj både antal barn idag och antal barn du planerar att ha.
             </div>
 
-            <div class="form-section">
+            <div class="form-section wizard-step">
                 <label for="inkomst1">Vad är din månadsinkomst före skatt?</label>
                 <input type="number" name="inkomst1" id="inkomst1" placeholder="30000 kr" required>
             </div>
-            <div id="avtal-question-1" class="form-section">
+            <div id="avtal-question-1" class="form-section wizard-step">
                 <label for="har-avtal-1">Har du kollektivavtal?</label>
                 <div class="button-group" id="avtal-group-1">
                     <button type="button" class="toggle-btn" data-value="ja">Ja</button>
@@ -88,12 +88,12 @@
                 <input type="hidden" name="har_avtal_1" id="har-avtal-1" value="">
             </div>
 
-            <div id="inkomst-block-2" style="display:none;" class="form-section">
+            <div id="inkomst-block-2" class="form-section wizard-step">
                 <label for="inkomst2">Månadsinkomst förälder 2 (före skatt):</label>
                 <input type="number" name="inkomst2" id="inkomst2" placeholder="30000 kr">
             </div>
 
-            <div id="avtal-question-2" class="form-section" style="display: none;">
+            <div id="avtal-question-2" class="form-section wizard-step">
                 <label for="har-avtal-2">Har din partner kollektivavtal?</label>
                 <div class="button-group" id="avtal-group-2">
                     <button type="button" class="toggle-btn" data-value="ja">Ja</button>
@@ -101,8 +101,8 @@
                 </div>
                 <input type="hidden" name="har_avtal_2" id="har-avtal-2" value="">
             </div>
-            
-            <button type="submit" id="calculate-btn">Visa resultat</button>
+
+            <button type="submit" id="calculate-btn" class="hidden">Visa resultat</button>
         </form>
 
         <div id="result-block"></div>
@@ -208,6 +208,7 @@
     <script type="module" src="{{ url_for('static', filename='ui.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='chart.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='index.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='wizard.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Create `wizard.js` to present form questions one at a time with progress tracking
- Update HTML and styles to support wizard flow and smooth transitions
- Simplify `index.js` initialization to defer question handling to the wizard

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b01f9ec83c832b83c683aebf379a08