### PR TITLE
Refine wizard layout and summary visuals

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -449,7 +449,7 @@ export function renderGanttChart(plan1, plan2, plan1NoExtra, plan2NoExtra, plan1
         const weekLabel = weekLabels[index] || 'Okänd vecka';
         let html = `<strong>${weekLabel}</strong><br>`;
         html += `Period: ${data.periodLabel || 'Okänd period'}<br>`;
-        html += `Kombinerad: ${data.y.toLocaleString()} kr/månad<br>`;
+        html += `Kombinerad: <span class="combined-income">${data.y.toLocaleString()} kr/månad</span><br>`;
         html += `<strong>Förälder 1</strong>: ${data.förälder1Inkomst.toLocaleString()} kr/månad<br>`;
         html += `  Föräldrapenning: ${data.förälder1Components.fp.toLocaleString()} kr/månad<br>`;
         html += `  Föräldralön: ${data.förälder1Components.extra.toLocaleString()} kr/månad<br>`;

--- a/static/index.js
+++ b/static/index.js
@@ -92,19 +92,19 @@ function handleFormSubmit(e) {
 
     // Parent 1 results
     const månadsinkomst1 = Math.round((dag1 * 7 * 4.3) / 100) * 100;
-    resultHtml += generateParentSection(
-        1, dag1, extra1, månadsinkomst1, förälder1InkomstDagar, 
-        avtal1 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg, 
-        vårdnad === 'ensam'
-    );
+        resultHtml += generateParentSection(
+            1, dag1, extra1, månadsinkomst1, förälder1InkomstDagar,
+            avtal1 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg,
+            vårdnad === 'ensam', inkomst1
+        );
 
     // Parent 2 results (if applicable)
     if (vårdnad === 'gemensam' && beräknaPartner === 'ja') {
         const månadsinkomst2 = Math.round((dag2 * 7 * 4.3) / 100) * 100;
         resultHtml += generateParentSection(
-            2, dag2, extra2, månadsinkomst2, förälder2InkomstDagar, 
-            avtal2 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg, 
-            false
+            2, dag2, extra2, månadsinkomst2, förälder2InkomstDagar,
+            avtal2 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg,
+            false, inkomst2
         );
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -37,8 +37,8 @@ h3 {
     transition: background-color 0.3s;
 }
 
-/* Undvik att alla .toggle-btn påverkas */
-.toggle-btn:not(.barnval .toggle-btn) {
+.button-group .toggle-btn {
+    width: auto;
     padding: 10px 20px;
 }
 
@@ -48,6 +48,7 @@ form {
     border-radius: 10px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     margin-bottom: 2rem;
+    position: relative;
 }
 
 label {
@@ -143,19 +144,6 @@ canvas {
     justify-content: center;
 }
 
-.button-group .toggle-btn {
-    width: 50px;
-    height: 50px;
-    padding: 0;
-    font-size: 18px;
-    text-align: center;
-    border-radius: 8px;
-    background-color: #e3e3e3;
-    font-weight: bold;
-    border: none;
-    cursor: pointer;
-    transition: background-color 0.3s;
-}
 
 .button-group .toggle-btn:hover {
     background-color: #d0d0d0;
@@ -178,8 +166,11 @@ canvas {
     color: #3bc9b2;
     font-weight: bold;
     cursor: pointer;
-    margin-bottom: 1rem;
-    align-self: flex-start;
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    width: auto;
+    margin: 0;
 }
 
 input[type="number"] {
@@ -370,6 +361,12 @@ input[type="number"] {
 
 .info-box.open .info-content {
     display: block;
+    text-align: left;
+}
+
+.combined-income {
+    color: #2e7d32;
+    font-weight: bold;
 }
 .days-split {
     margin-top: 1rem;

--- a/static/ui.js
+++ b/static/ui.js
@@ -97,15 +97,16 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
  * @param {number} parentNum - Parent number (1 or 2)
  * @param {number} dag - Daily benefit rate
  * @param {number} extra - Parental supplement
- * @param {number} månadsinkomst - Monthly income
+ * @param {number} månadsinkomst - Monthly parental benefit
  * @param {number} dagar - Available days
  * @param {boolean} avtal - Has collective agreement
  * @param {number} barnbidrag - Child allowance
  * @param {number} tillägg - Additional child allowance
  * @param {boolean} ärEnsam - True if sole custody
+ * @param {number} inkomst - Reported salary
  * @returns {string} HTML section string
- */
-export function generateParentSection(parentNum, dag, extra, månadsinkomst, dagar, avtal, barnbidrag, tillägg, ärEnsam) {
+*/
+export function generateParentSection(parentNum, dag, extra, månadsinkomst, dagar, avtal, barnbidrag, tillägg, ärEnsam, inkomst) {
     const lagstanivådagar = Math.round(dagar * 0.23076923);
     const gemensamDetails = `
         <div class="benefit-details">
@@ -137,6 +138,10 @@ export function generateParentSection(parentNum, dag, extra, månadsinkomst, dag
                     </div>
                 </div>
                 <div class="benefit-card">
+                    <div class="benefit-title">Månadsinkomst</div>
+                    <div class="benefit-value-large">
+                        <span>${inkomst.toLocaleString()}</span><span class="unit">kr/månad</span>
+                    </div>
                     <div class="benefit-title">Preliminär föräldralön</div>
                     <div class="benefit-value-large">
                         <span>${extra.toLocaleString()}</span><span class="unit">kr/månad</span>

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -11,10 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
         partner: document.getElementById('partner-question'),
         barnIdag: document.querySelector('#barn-tidigare-group').closest('.wizard-step'),
         barnPlan: document.querySelector('#barn-planerade-group').closest('.wizard-step'),
-        inkomst1: document.getElementById('inkomst1').closest('.wizard-step'),
-        avtal1: document.getElementById('avtal-question-1'),
-        inkomst2: document.getElementById('inkomst-block-2'),
-        avtal2: document.getElementById('avtal-question-2')
+        inkomst1: document.getElementById('inkomst-avtal-1'),
+        inkomst2: document.getElementById('inkomst-block-2')
     };
 
     const stepSections = [
@@ -23,9 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
         sections.barnIdag,
         sections.barnPlan,
         sections.inkomst1,
-        sections.avtal1,
-        sections.inkomst2,
-        sections.avtal2
+        sections.inkomst2
     ];
 
     const idx = {
@@ -34,10 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
         barnIdag: 2,
         barnPlan: 3,
         inkomst1: 4,
-        avtal1: 5,
-        inkomst2: 6,
-        avtal2: 7,
-        calc: 8
+        inkomst2: 5,
+        calc: 6
     };
 
     const calculateBtn = document.getElementById('calculate-btn');
@@ -51,8 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
     function progressStepForIndex(i) {
         if (i === idx.calc) return 7;
         if (i <= idx.barnPlan) return i + 1;
-        if (i === idx.inkomst1 || i === idx.avtal1) return 5;
-        if (i === idx.inkomst2 || i === idx.avtal2) return 6;
+        if (i === idx.inkomst1) return 5;
+        if (i === idx.inkomst2) return 6;
         return 1;
     }
 
@@ -67,11 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateProgress(progressStepForIndex(currentIndex));
         backBtn.classList.toggle('hidden', history.length === 0);
 
-        const finalStep = (!partnerSelected && currentIndex === idx.avtal1) ||
-            (partnerSelected && currentIndex === idx.avtal2) ||
-            currentIndex === idx.calc;
-
-        if (finalStep) calculateBtn.classList.remove('hidden');
+        if (currentIndex === idx.calc) calculateBtn.classList.remove('hidden');
     }
 
     function goTo(nextIndex) {
@@ -136,27 +126,11 @@ document.addEventListener('DOMContentLoaded', () => {
         goTo(idx.inkomst1);
     });
 
-    const inkomst1Input = document.getElementById('inkomst1');
-    inkomst1Input.addEventListener('keydown', e => {
-        if (e.key === 'Enter' && inkomst1Input.value !== '') {
-            e.preventDefault();
-            goTo(idx.avtal1);
-        }
-    });
-
     setupToggleButtons('avtal-group-1', 'har-avtal-1', () => {
         if (partnerSelected) {
             goTo(idx.inkomst2);
         } else {
             goTo(idx.calc);
-        }
-    });
-
-    const inkomst2Input = document.getElementById('inkomst2');
-    inkomst2Input.addEventListener('keydown', e => {
-        if (e.key === 'Enter' && inkomst2Input.value !== '') {
-            e.preventDefault();
-            goTo(idx.avtal2);
         }
     });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,12 +82,10 @@
                 Vänligen välj både antal barn idag och antal barn du planerar att ha.
             </div>
 
-            <div class="form-section wizard-step">
+            <div class="form-section wizard-step" id="inkomst-avtal-1">
                 <div class="question-icon"><i class="fa-solid fa-money-bill"></i></div>
                 <label for="inkomst1">Vad är din månadsinkomst före skatt?</label>
                 <input type="number" name="inkomst1" id="inkomst1" placeholder="30000 kr" required>
-            </div>
-            <div id="avtal-question-1" class="form-section wizard-step">
                 <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
                 <label for="har-avtal-1">Har du kollektivavtal?</label>
                 <div class="button-group" id="avtal-group-1">
@@ -101,9 +99,6 @@
                 <div class="question-icon"><i class="fa-solid fa-money-bill"></i></div>
                 <label for="inkomst2">Månadsinkomst förälder 2 (före skatt):</label>
                 <input type="number" name="inkomst2" id="inkomst2" placeholder="30000 kr">
-            </div>
-
-            <div id="avtal-question-2" class="form-section wizard-step">
                 <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
                 <label for="har-avtal-2">Har din partner kollektivavtal?</label>
                 <div class="button-group" id="avtal-group-2">


### PR DESCRIPTION
## Summary
- Combine each parent's income and collective agreement into single wizard steps.
- Adjust styling for long-text buttons, reposition the back button, and left-align household expense info.
- Display salary above preliminary parental pay and highlight combined income in green in summary box.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b02be0ec68832b8b9fd02b2d3bc587