### PR TITLE
Improve benefit display and optimize leave validation

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -126,6 +126,10 @@ export function optimizeParentalLeave(preferences, inputs) {
             dagarPerVecka1 = maxDagarPerVecka;
             inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
             kombineradInkomst = inkomst1Result + inkomst2Result;
+            if (kombineradInkomst < minInkomst) {
+                genomförbarhet.ärGenomförbar = false;
+                genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
+            }
         }
 
         let totalDagarBehövda1 = weeks1 * dagarPerVecka1;
@@ -173,6 +177,10 @@ export function optimizeParentalLeave(preferences, inputs) {
             dagarPerVecka2 = maxDagarPerVecka;
             inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
             kombineradInkomst = inkomst1Result + inkomst2Result;
+            if (kombineradInkomst < minInkomst) {
+                genomförbarhet.ärGenomförbar = false;
+                genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
+            }
         }
 
         let totalDagarBehövda2 = weeks2 * dagarPerVecka2;

--- a/static/index.js
+++ b/static/index.js
@@ -219,15 +219,32 @@ function handleOptimize() {
         const result = optimizeParentalLeave(preferences, inputs);
 
         // Validate leave duration
-        const totalDays1 = result.plan1.användaInkomstDagar + result.plan1.användaMinDagar;
-        const totalDays2 = result.plan2.användaInkomstDagar + result.plan2.användaMinDagar;
-        if (totalDays1 > förälder1InkomstDagar + förälder1MinDagar || 
-            totalDays2 > förälder2InkomstDagar + förälder2MinDagar) {
-            document.getElementById('leave-duration-error').style.display = 'block';
+        if (!result.genomförbarhet.ärGenomförbar) {
+            const err = document.getElementById('leave-duration-error');
+            err.textContent = result.genomförbarhet.meddelande;
+            err.style.display = 'block';
             return;
-        } else {
-            document.getElementById('leave-duration-error').style.display = 'none';
         }
+
+        const totalDays1 =
+            result.plan1.användaInkomstDagar +
+            result.plan1.användaMinDagar +
+            result.plan1NoExtra.weeks * result.plan1NoExtra.dagarPerVecka;
+        const totalDays2 =
+            result.plan2.användaInkomstDagar +
+            result.plan2.användaMinDagar +
+            result.plan2NoExtra.weeks * result.plan2NoExtra.dagarPerVecka;
+        const transferred = result.genomförbarhet.transferredDays || 0;
+        const maxDays1 = förälder1InkomstDagar + förälder1MinDagar + transferred;
+        const maxDays2 = förälder2InkomstDagar + förälder2MinDagar - transferred;
+
+        const errorElement = document.getElementById('leave-duration-error');
+        if (totalDays1 > maxDays1 || totalDays2 > maxDays2) {
+            errorElement.style.display = 'block';
+            return;
+        }
+
+        errorElement.style.display = 'none';
 
         // Render Gantt chart
         document.getElementById('optimization-result').style.display = 'block';

--- a/static/script.js
+++ b/static/script.js
@@ -1345,7 +1345,7 @@ document.addEventListener("DOMContentLoaded", function () {
                             </div>
                             ${inputs.avtal1 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra1.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
-                            <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tilläggPerPerson.toLocaleString()} kr/månad</span></div>
+                            <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tillägg.toLocaleString()} kr/månad</span></div>
                         </div>
                         ${inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && inputs.inkomst2 > 0 ? `
                         <div class="total-section parent-2">
@@ -1356,7 +1356,7 @@ document.addEventListener("DOMContentLoaded", function () {
                             </div>
                             ${inputs.avtal2 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra2.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
-                            <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tilläggPerPerson.toLocaleString()} kr/månad</span></div>
+                            <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tillägg.toLocaleString()} kr/månad</span></div>
                         </div>` : ''}
                     </div>
                     <div class="montly-footer">

--- a/static/style.css
+++ b/static/style.css
@@ -173,6 +173,13 @@ canvas {
     margin: 0;
 }
 
+#calculate-btn {
+    width: auto;
+    max-width: 300px;
+    margin: 1.5rem auto 3rem;
+    display: block;
+}
+
 input[type="number"] {
     max-width: 300px;
     margin: 0 auto;

--- a/static/ui.js
+++ b/static/ui.js
@@ -142,7 +142,7 @@ export function generateParentSection(parentNum, dag, extra, månadsinkomst, dag
                     <div class="benefit-value-large">
                         <span>${inkomst.toLocaleString()}</span><span class="unit">kr/månad</span>
                     </div>
-                    <div class="benefit-title">Preliminär föräldralön</div>
+                    <div class="benefit-title" style="margin-top: 0.5rem;">Preliminär föräldralön</div>
                     <div class="benefit-value-large">
                         <span>${extra.toLocaleString()}</span><span class="unit">kr/månad</span>
                     </div>


### PR DESCRIPTION
## Summary
- Add spacing before the "Preliminär föräldralön" label in benefit cards for clearer layout
- Prevent back button overlap by constraining the result button size and spacing
- Correct Flerbarnstillägg values in the summary box and refine leave-duration validation with income checks

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b030799ea0832baaf6ab1be030c5aa