### PR TITLE
Add parental leave distribution slider

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -48,6 +48,9 @@ function setupEventListeners() {
 
     // Dropdown listeners for uttag
     setupDropdownListeners();
+
+    // Leave distribution slider
+    setupLeaveSlider();
 }
 
 
@@ -169,7 +172,6 @@ function handleOptimize() {
     updateProgress(8);
     const barnDatumInput = document.getElementById('barn-datum');
     const ledigTid1Input = document.getElementById('ledig-tid-5823');
-    const ledigTid2Input = document.getElementById('ledig-tid-2');
     const minInkomstInput = document.getElementById('min-inkomst');
     const strategyInput = document.getElementById('strategy');
 
@@ -182,8 +184,10 @@ function handleOptimize() {
     }
 
     const barnDatum = barnDatumInput.value || '2025-05-01';
-    const ledigTid1 = parseFloat(ledigTid1Input.value) || 6;
-    const ledigTid2 = window.appState.beräknaPartner === 'ja' && ledigTid2Input ? parseFloat(ledigTid2Input.value) || 0 : 0;
+    const totalMonths = parseFloat(ledigTid1Input.value) || 0;
+    const slider = document.getElementById('leave-slider');
+    const ledigTid1 = slider ? parseFloat(slider.value) || 0 : 0;
+    const ledigTid2 = Math.max(totalMonths - ledigTid1, 0);
     const minInkomst = parseInt(minInkomstInput.value) || 10000;
     const strategy = strategyInput.value || 'longer';
     const deltid = defaultPreferences.deltid; // From config, could be made dynamic
@@ -281,4 +285,38 @@ function handleOptimize() {
         document.getElementById('leave-duration-error').textContent = 
             'Fel vid optimering: Kontrollera indata och försök igen.';
     }
+}
+
+function setupLeaveSlider() {
+    const totalInput = document.getElementById('ledig-tid-5823');
+    const slider = document.getElementById('leave-slider');
+    const container = document.getElementById('leave-slider-container');
+    if (!totalInput || !slider || !container) return;
+
+    container.style.display = 'none';
+
+    totalInput.addEventListener('input', () => {
+        const total = parseInt(totalInput.value) || 0;
+        slider.max = total;
+        const half = Math.floor(total / 2);
+        slider.value = half;
+        updateLeaveDisplay(slider, total);
+        container.style.display = total > 0 ? 'block' : 'none';
+    });
+
+    slider.addEventListener('input', () => {
+        const total = parseInt(totalInput.value) || 0;
+        updateLeaveDisplay(slider, total);
+    });
+}
+
+function updateLeaveDisplay(slider, total) {
+    const p1 = parseInt(slider.value) || 0;
+    const p2 = Math.max(total - p1, 0);
+    const p1Elem = document.getElementById('p1-months');
+    const p2Elem = document.getElementById('p2-months');
+    if (p1Elem) p1Elem.textContent = p1;
+    if (p2Elem) p2Elem.textContent = p2;
+    const percent = total > 0 ? (p1 / total) * 100 : 0;
+    slider.style.background = `linear-gradient(to right, green 0%, green ${percent}%, blue ${percent}%, blue 100%)`;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1020,3 +1020,37 @@ canvas#gantt-canvas {
 .hidden {
     display: none;
 }
+
+/* Slider for distributing leave between parents */
+#leave-slider {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    border-radius: 5px;
+    background: linear-gradient(to right, green 50%, blue 50%);
+    outline: none;
+}
+#leave-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: gray;
+    cursor: pointer;
+    border: none;
+}
+#leave-slider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: gray;
+    cursor: pointer;
+    border: none;
+}
+#leave-slider-container {
+    margin-top: 10px;
+}
+.slider-values {
+    text-align: center;
+    margin-top: 8px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,6 +131,13 @@
                 <label>Hur länge vill du vara ledig? (månader)</label>
                 <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
             </div>
+            <div class="preference-group" id="leave-slider-container" style="display: none;">
+                <input type="range" id="leave-slider" min="0" max="0" value="0" step="1">
+                <div class="slider-values">
+                    <span id="p1-months">0</span> månader för förälder 1 –
+                    <span id="p2-months">0</span> månader för förälder 2
+                </div>
+            </div>
             <div class="preference-group" id="parent-ledig-tid" style="display: none;">
                 <label>Hur länge vill din partner vara ledig? (månader)</label>
                 <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">

--- a/templates/index.js
+++ b/templates/index.js
@@ -65,6 +65,9 @@ function setupEventListeners() {
 
     // Dropdown listeners for uttag
     setupDropdownListeners();
+
+    // Leave distribution slider
+    setupLeaveSlider();
 }
 
 /**
@@ -227,7 +230,6 @@ function setupDropdownListeners() {
 function handleOptimize() {
     const barnDatumInput = document.getElementById('barn-datum');
     const ledigTid1Input = document.getElementById('ledig-tid-5823');
-    const ledigTid2Input = document.getElementById('ledig-tid-2');
     const minInkomstInput = document.getElementById('min-inkomst');
     const strategyInput = document.getElementById('strategy');
 
@@ -240,8 +242,10 @@ function handleOptimize() {
     }
 
     const barnDatum = barnDatumInput.value || '2025-05-01';
-    const ledigTid1 = parseFloat(ledigTid1Input.value) || 6;
-    const ledigTid2 = window.appState.beräknaPartner === 'ja' && ledigTid2Input ? parseFloat(ledigTid2Input.value) || 0 : 0;
+    const totalMonths = parseFloat(ledigTid1Input.value) || 0;
+    const slider = document.getElementById('leave-slider');
+    const ledigTid1 = slider ? parseFloat(slider.value) || 0 : 0;
+    const ledigTid2 = Math.max(totalMonths - ledigTid1, 0);
     const minInkomst = parseInt(minInkomstInput.value) || 10000;
     const strategy = strategyInput.value || 'longer';
     const deltid = defaultPreferences.deltid; // From config, could be made dynamic
@@ -322,4 +326,38 @@ function handleOptimize() {
         document.getElementById('leave-duration-error').textContent = 
             'Fel vid optimering: Kontrollera indata och försök igen.';
     }
+}
+
+function setupLeaveSlider() {
+    const totalInput = document.getElementById('ledig-tid-5823');
+    const slider = document.getElementById('leave-slider');
+    const container = document.getElementById('leave-slider-container');
+    if (!totalInput || !slider || !container) return;
+
+    container.style.display = 'none';
+
+    totalInput.addEventListener('input', () => {
+        const total = parseInt(totalInput.value) || 0;
+        slider.max = total;
+        const half = Math.floor(total / 2);
+        slider.value = half;
+        updateLeaveDisplay(slider, total);
+        container.style.display = total > 0 ? 'block' : 'none';
+    });
+
+    slider.addEventListener('input', () => {
+        const total = parseInt(totalInput.value) || 0;
+        updateLeaveDisplay(slider, total);
+    });
+}
+
+function updateLeaveDisplay(slider, total) {
+    const p1 = parseInt(slider.value) || 0;
+    const p2 = Math.max(total - p1, 0);
+    const p1Elem = document.getElementById('p1-months');
+    const p2Elem = document.getElementById('p2-months');
+    if (p1Elem) p1Elem.textContent = p1;
+    if (p2Elem) p2Elem.textContent = p2;
+    const percent = total > 0 ? (p1 / total) * 100 : 0;
+    slider.style.background = `linear-gradient(to right, green 0%, green ${percent}%, blue ${percent}%, blue 100%)`;
 }


### PR DESCRIPTION
## Summary
- add slider to allocate parental leave months between parents
- style slider with green and blue track and grey handle
- calculate parent-specific leave durations during optimization

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b035053a04832bb612b137ddd4f756