### PR TITLE
Fix result button visibility and initialize leave slider

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -293,21 +293,25 @@ function setupLeaveSlider() {
     const container = document.getElementById('leave-slider-container');
     if (!totalInput || !slider || !container) return;
 
-    container.style.display = 'none';
-
-    totalInput.addEventListener('input', () => {
+    // Sync slider state with total leave and toggle visibility
+    const syncSlider = () => {
         const total = parseInt(totalInput.value) || 0;
         slider.max = total;
         const half = Math.floor(total / 2);
         slider.value = half;
         updateLeaveDisplay(slider, total);
         container.style.display = total > 0 ? 'block' : 'none';
-    });
+    };
+
+    totalInput.addEventListener('input', syncSlider);
+    totalInput.addEventListener('change', syncSlider);
 
     slider.addEventListener('input', () => {
         const total = parseInt(totalInput.value) || 0;
         updateLeaveDisplay(slider, total);
     });
+
+    syncSlider();
 }
 
 function updateLeaveDisplay(slider, total) {

--- a/static/style.css
+++ b/static/style.css
@@ -180,6 +180,10 @@ canvas {
     display: block;
 }
 
+#calculate-btn.hidden {
+    display: none;
+}
+
 input[type="number"] {
     max-width: 300px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- Hide the "Visa resultat" button until the final step by adding a specific CSS rule for its hidden state
- Initialize and synchronize the leave distribution slider with total leave input so it appears when data is entered

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0377fa238832bb3e396ed412651fc