### PR TITLE
Improve slider visuals and child benefit summary

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -449,18 +449,18 @@ export function renderGanttChart(plan1, plan2, plan1NoExtra, plan2NoExtra, plan1
         const weekLabel = weekLabels[index] || 'Okänd vecka';
         let html = `<strong>${weekLabel}</strong><br>`;
         html += `Period: ${data.periodLabel || 'Okänd period'}<br>`;
-        html += `Kombinerad: <span class="combined-income">${data.y.toLocaleString()} kr/månad</span><br>`;
+        html += `Kombinerad: <span class="combined-income">${data.y.toLocaleString()} kr/månad</span><br><br>`;
         html += `<strong>Förälder 1</strong>: ${data.förälder1Inkomst.toLocaleString()} kr/månad<br>`;
         html += `  Föräldrapenning: ${data.förälder1Components.fp.toLocaleString()} kr/månad<br>`;
         html += `  Föräldralön: ${data.förälder1Components.extra.toLocaleString()} kr/månad<br>`;
         html += `  Barnbidrag: ${data.förälder1Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-        html += `  Flerbarnstillägg: ${data.förälder1Components.tillägg.toLocaleString()} kr/månad<br>`;
+        html += `  Flerbarnstillägg: ${data.förälder1Components.tillägg.toLocaleString()} kr/månad<br><br>`;
         if (vårdnad !== 'ensam') {
             html += `<strong>Förälder 2</strong>: ${data.förälder2Inkomst.toLocaleString()} kr/månad<br>`;
             html += `  Föräldrapenning: ${data.förälder2Components.fp.toLocaleString()} kr/månad<br>`;
             html += `  Föräldralön: ${data.förälder2Components.extra.toLocaleString()} kr/månad<br>`;
             html += `  Barnbidrag: ${data.förälder2Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-            html += `  Flerbarnstillägg: ${data.förälder2Components.tillägg.toLocaleString()} kr/månad`;
+            html += `  Flerbarnstillägg: ${data.förälder2Components.tillägg.toLocaleString()} kr/månad<br><br>`;
         }
         return html;
     }

--- a/static/config.js
+++ b/static/config.js
@@ -19,8 +19,18 @@ export const förälder1MinDagar = 45; // Minimum reserved days for Parent 1
 export const förälder2MinDagar = 45; // Minimum reserved days for Parent 2
 
 // Benefits
-export const barnbidragPerPerson = 625; // Child allowance per person (SEK/month)
-export const tilläggPerPerson = 0; // Additional allowance per person (SEK/month)
+export let barnbidragPerPerson = 625; // Child allowance per person (SEK/month)
+export let tilläggPerPerson = 0; // Additional allowance per person (SEK/month)
+
+/**
+ * Update child benefit and supplement amounts per parent.
+ * @param {number} bidrag - Child allowance per parent
+ * @param {number} tillägg - Flerbarnstillägg per parent
+ */
+export function setBarnBenefits(bidrag, tillägg) {
+    barnbidragPerPerson = bidrag;
+    tilläggPerPerson = tillägg;
+}
 
 // Constants
 export const INCOME_CAP = 1250; // SEK/day max parental benefit

--- a/static/index.js
+++ b/static/index.js
@@ -2,8 +2,8 @@
  * index.js - Main initialization and form handling for the Föräldrapenningkalkylator
  * Sets up event listeners and orchestrates calculations, UI, and chart rendering.
  */
-import { 
-    vårdnad, beräknaPartner, barnbidragPerPerson, tilläggPerPerson, 
+import {
+    vårdnad, beräknaPartner, setBarnBenefits,
     barnIdag, barnPlanerat, hasCalculated, defaultPreferences,
     förälder1InkomstDagar, förälder2InkomstDagar, förälder1MinDagar, förälder2MinDagar
 } from './config.js';
@@ -82,6 +82,7 @@ function handleFormSubmit(e) {
     // Calculate child benefits
     const totalBarn = barnTidigare + barnPlanerade;
     const barnbidragResult = beräknaBarnbidrag(totalBarn, vårdnad === 'ensam');
+    setBarnBenefits(barnbidragResult.barnbidrag, barnbidragResult.tillägg);
 
     // Calculate daily rates and parental supplement
     const dag1 = beräknaDaglig(inkomst1);
@@ -291,6 +292,8 @@ function setupLeaveSlider() {
     const totalInput = document.getElementById('ledig-tid-5823');
     const slider = document.getElementById('leave-slider');
     const container = document.getElementById('leave-slider-container');
+    const minLabel = document.getElementById('slider-start');
+    const maxLabel = document.getElementById('slider-end');
     if (!totalInput || !slider || !container) return;
 
     // Sync slider state with total leave and toggle visibility
@@ -300,6 +303,8 @@ function setupLeaveSlider() {
         const half = Math.floor(total / 2);
         slider.value = half;
         updateLeaveDisplay(slider, total);
+        if (minLabel) minLabel.textContent = '0';
+        if (maxLabel) maxLabel.textContent = total;
         container.style.display = total > 0 ? 'block' : 'none';
     };
 
@@ -322,5 +327,17 @@ function updateLeaveDisplay(slider, total) {
     if (p1Elem) p1Elem.textContent = p1;
     if (p2Elem) p2Elem.textContent = p2;
     const percent = total > 0 ? (p1 / total) * 100 : 0;
-    slider.style.background = `linear-gradient(to right, green 0%, green ${percent}%, blue ${percent}%, blue 100%)`;
+    const green = '#28a745';
+    const blue = '#007bff';
+    const base = `linear-gradient(to right, ${green} 0%, ${green} ${percent}%, ${blue} ${percent}%, ${blue} 100%)`;
+    if (total > 2) {
+        const step = 100 / total;
+        const grid =
+            `repeating-linear-gradient(to right, transparent, transparent ` +
+            `calc(${step}% - 1px), rgba(255,255,255,0.7) calc(${step}% - 1px), ` +
+            `rgba(255,255,255,0.7) ${step}%)`;
+        slider.style.background = `${grid}, ${base}`;
+    } else {
+        slider.style.background = base;
+    }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1031,7 +1031,7 @@ canvas#gantt-canvas {
     width: 100%;
     height: 8px;
     border-radius: 5px;
-    background: linear-gradient(to right, green 50%, blue 50%);
+    background: linear-gradient(to right, #28a745 50%, #007bff 50%);
     outline: none;
 }
 #leave-slider::-webkit-slider-thumb {
@@ -1053,6 +1053,12 @@ canvas#gantt-canvas {
 }
 #leave-slider-container {
     margin-top: 10px;
+}
+.slider-scale {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9em;
+    margin-top: 4px;
 }
 .slider-values {
     text-align: center;

--- a/templates/chart.js
+++ b/templates/chart.js
@@ -449,18 +449,18 @@ export function renderGanttChart(plan1, plan2, plan1NoExtra, plan2NoExtra, plan1
         const weekLabel = weekLabels[index] || 'Okänd vecka';
         let html = `<strong>${weekLabel}</strong><br>`;
         html += `Period: ${data.periodLabel || 'Okänd period'}<br>`;
-        html += `Kombinerad: ${data.y.toLocaleString()} kr/månad<br>`;
+        html += `Kombinerad: ${data.y.toLocaleString()} kr/månad<br><br>`;
         html += `<strong>Förälder 1</strong>: ${data.förälder1Inkomst.toLocaleString()} kr/månad<br>`;
         html += `  Föräldrapenning: ${data.förälder1Components.fp.toLocaleString()} kr/månad<br>`;
         html += `  Föräldralön: ${data.förälder1Components.extra.toLocaleString()} kr/månad<br>`;
         html += `  Barnbidrag: ${data.förälder1Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-        html += `  Flerbarnstillägg: ${data.förälder1Components.tillägg.toLocaleString()} kr/månad<br>`;
+        html += `  Flerbarnstillägg: ${data.förälder1Components.tillägg.toLocaleString()} kr/månad<br><br>`;
         if (vårdnad !== 'ensam') {
             html += `<strong>Förälder 2</strong>: ${data.förälder2Inkomst.toLocaleString()} kr/månad<br>`;
             html += `  Föräldrapenning: ${data.förälder2Components.fp.toLocaleString()} kr/månad<br>`;
             html += `  Föräldralön: ${data.förälder2Components.extra.toLocaleString()} kr/månad<br>`;
             html += `  Barnbidrag: ${data.förälder2Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-            html += `  Flerbarnstillägg: ${data.förälder2Components.tillägg.toLocaleString()} kr/månad`;
+            html += `  Flerbarnstillägg: ${data.förälder2Components.tillägg.toLocaleString()} kr/månad<br><br>`;
         }
         return html;
     }

--- a/templates/config.js
+++ b/templates/config.js
@@ -19,8 +19,18 @@ export const förälder1MinDagar = 45; // Minimum reserved days for Parent 1
 export const förälder2MinDagar = 45; // Minimum reserved days for Parent 2
 
 // Benefits
-export const barnbidragPerPerson = 625; // Child allowance per person (SEK/month)
-export const tilläggPerPerson = 0; // Additional allowance per person (SEK/month)
+export let barnbidragPerPerson = 625; // Child allowance per person (SEK/month)
+export let tilläggPerPerson = 0; // Additional allowance per person (SEK/month)
+
+/**
+ * Update child benefit and supplement amounts per parent.
+ * @param {number} bidrag - Child allowance per parent
+ * @param {number} tillägg - Flerbarnstillägg per parent
+ */
+export function setBarnBenefits(bidrag, tillägg) {
+    barnbidragPerPerson = bidrag;
+    tilläggPerPerson = tillägg;
+}
 
 // Constants
 export const INCOME_CAP = 1250; // SEK/day max parental benefit

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,6 +133,10 @@
             </div>
             <div class="preference-group" id="leave-slider-container" style="display: none;">
                 <input type="range" id="leave-slider" min="0" max="0" value="0" step="1">
+                <div class="slider-scale">
+                    <span id="slider-start">0</span>
+                    <span id="slider-end">0</span>
+                </div>
                 <div class="slider-values">
                     <span id="p1-months">0</span> månader för förälder 1 –
                     <span id="p2-months">0</span> månader för förälder 2


### PR DESCRIPTION
## Summary
- Update leave distribution slider with lighter green/blue, monthly gridlines, and end labels
- Fix child benefit calculations so barnbidrag and flerbarnstillägg reflect all children
- Add spacing in summary box for clearer combined and per-parent incomes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0439a10ac832ba1f5c19f4ee54c61