### PR TITLE
Improve slider and summary display

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -474,23 +474,38 @@ export function renderGanttChart(
         }
         const data = inkomstData[index];
         const weekLabel = weekLabels[index] || 'Okänd vecka';
-        let html = `<strong>${weekLabel}</strong><br>`;
-        html += `Period: ${data.periodLabel || 'Okänd period'}<br>`;
-        html += `Kombinerad: <span class="combined-income">${data.y.toLocaleString()} kr/månad</span><br>`;
-        html += `<strong>Förälder 1</strong>: ${data.förälder1Inkomst.toLocaleString()} kr/månad<br>`;
-        html += `  Föräldrapenning: ${data.förälder1Components.fp.toLocaleString()} kr/månad<br>`;
-        html += `  Föräldralön: ${data.förälder1Components.extra.toLocaleString()} kr/månad<br>`;
-        html += `  Barnbidrag: ${data.förälder1Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-        html += `  Flerbarnstillägg: ${data.förälder1Components.tillägg.toLocaleString()} kr/månad<br>`;
+        let html =
+            `<div class="summary-section"><strong>${weekLabel}</strong><br>` +
+            `Period: ${data.periodLabel || 'Okänd period'}</div>`;
+        html +=
+            `<div class="summary-section">Total inkomst: ` +
+            `<span class="combined-income">${data.y.toLocaleString()} kr/månad</span></div>`;
+        html +=
+            `<div class="summary-section"><strong>Förälder 1</strong>: ` +
+            `${data.förälder1Inkomst.toLocaleString()} kr/månad<br>`;
+        html += `  Föräldrapenning: ` +
+            `${data.förälder1Components.fp.toLocaleString()} kr/månad<br>`;
+        html += `  Föräldralön: ` +
+            `${data.förälder1Components.extra.toLocaleString()} kr/månad<br>`;
+        html += `  Barnbidrag: ` +
+            `${data.förälder1Components.barnbidrag.toLocaleString()} kr/månad<br>`;
+        html += `  Flerbarnstillägg: ` +
+            `${data.förälder1Components.tillägg.toLocaleString()} kr/månad</div>`;
         const showParent2 = vårdnad !== 'ensam' && beräknaPartner === 'ja';
         if (showParent2) {
-            html += `<strong>Förälder 2</strong>: ${data.förälder2Inkomst.toLocaleString()} kr/månad<br>`;
-            html += `  Föräldrapenning: ${data.förälder2Components.fp.toLocaleString()} kr/månad<br>`;
-            html += `  Föräldralön: ${data.förälder2Components.extra.toLocaleString()} kr/månad<br>`;
-            html += `  Barnbidrag: ${data.förälder2Components.barnbidrag.toLocaleString()} kr/månad<br>`;
-            html += `  Flerbarnstillägg: ${data.förälder2Components.tillägg.toLocaleString()} kr/månad<br>`;
+            html +=
+                `<div class="summary-section"><strong>Förälder 2</strong>: ` +
+                `${data.förälder2Inkomst.toLocaleString()} kr/månad<br>`;
+            html += `  Föräldrapenning: ` +
+                `${data.förälder2Components.fp.toLocaleString()} kr/månad<br>`;
+            html += `  Föräldralön: ` +
+                `${data.förälder2Components.extra.toLocaleString()} kr/månad<br>`;
+            html += `  Barnbidrag: ` +
+                `${data.förälder2Components.barnbidrag.toLocaleString()} kr/månad<br>`;
+            html += `  Flerbarnstillägg: ` +
+                `${data.förälder2Components.tillägg.toLocaleString()} kr/månad</div>`;
         }
-        return html + '<br>';
+        return html;
     }
 
     // Custom plugin for summary box updates

--- a/static/style.css
+++ b/static/style.css
@@ -1059,6 +1059,24 @@ canvas#gantt-canvas {
     margin-top: 8px;
 }
 
+.slider-value {
+    display: block;
+    margin: 2px 0;
+    font-weight: 500;
+}
+
+.p1-value {
+    color: #28a745;
+}
+
+.p2-value {
+    color: #007bff;
+}
+
+.summary-section {
+    margin-bottom: 10px;
+}
+
 .slider-labels {
     display: flex;
     justify-content: space-between;

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,8 +139,8 @@
                     <span id="slider-end">0</span>
                 </div>
                 <div class="slider-values">
-                    <span id="p1-months">0</span> månader för förälder 1 –
-                    <span id="p2-months">0</span> månader för förälder 2
+                    <span class="slider-value p1-value">Förälder 1: <span id="p1-months">0</span> månader</span>
+                    <span class="slider-value p2-value">Förälder 2: <span id="p2-months">0</span> månader</span>
                 </div>
             </div>
             <div class="preference-group" id="parent-ledig-tid" style="display: none;">


### PR DESCRIPTION
## Summary
- Separate parental leave slider values and color-code each parent's months
- Add spacing between total and individual incomes in the summary box
- Style updates for new slider value and summary sections

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b05e5bb8ec832bb19e71811fb2bbfd