### PR TITLE
Honor requested leave & fix supplement logic

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -80,9 +80,9 @@ export function optimizeParentalLeave(preferences, inputs) {
     }
 
     const dag1 = beräknaDaglig(inkomst1);
-    const extra1 = inputs.avtal1 ? (inkomst1 <= SGI_CAP ? Math.round(inkomst1 * 0.10) : FÖRÄLDRALÖN_CAP) : 0;
+    const extra1 = inputs.avtal1 === "ja" ? (inkomst1 <= SGI_CAP ? Math.round(inkomst1 * 0.10) : FÖRÄLDRALÖN_CAP) : 0;
     const dag2 = inkomst2 > 0 ? beräknaDaglig(inkomst2) : 0;
-    const extra2 = inputs.avtal2 ? (inkomst2 <= SGI_CAP ? Math.round(inkomst2 * 0.10) : FÖRÄLDRALÖN_CAP) : 0;
+    const extra2 = inputs.avtal2 === "ja" ? (inkomst2 <= SGI_CAP ? Math.round(inkomst2 * 0.10) : FÖRÄLDRALÖN_CAP) : 0;
 
     let förälder1InkomstDagar = inputs.vårdnad === "ensam" ? 390 : 195;
     let förälder2InkomstDagar = inputs.vårdnad === "ensam" ? 0 : 195;
@@ -104,10 +104,36 @@ export function optimizeParentalLeave(preferences, inputs) {
     let inkomst2Result = arbetsInkomst2;
     let kombineradInkomst = 0;
 
+    const maxDagarPerVecka = deltid === "ja" ? 5 : 7;
+    dagarPerVecka1 = strategy === "maximize" ? maxDagarPerVecka : 1;
+    dagarPerVecka2 = inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" ? (strategy === "maximize" ? maxDagarPerVecka : 1) : 0;
+
+    let totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+    let totalDagarBehövda2 = weeks2 * dagarPerVecka2;
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && totalDagarBehövda1 > förälder1InkomstDagar) {
+        const förväntadeDagar2 = strategy === "maximize" ? maxDagarPerVecka : 1;
+        const minDagarBehövda2 = weeks2 * förväntadeDagar2;
+        const överförbaraDagar2 = Math.max(0, förälder2InkomstDagar - 90 - minDagarBehövda2 - 10);
+        const överförDagar = Math.min(överförbaraDagar2, totalDagarBehövda1 - förälder1InkomstDagar);
+        förälder2InkomstDagar -= överförDagar;
+        förälder1InkomstDagar += överförDagar;
+        totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+        genomförbarhet.transferredDays += överförDagar;
+    }
+
+    if (totalDagarBehövda1 > förälder1InkomstDagar) {
+        totalDagarBehövda1 = förälder1InkomstDagar;
+        weeks1 = Math.floor(totalDagarBehövda1 / dagarPerVecka1) || 1;
+    }
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && totalDagarBehövda2 > förälder2InkomstDagar) {
+        totalDagarBehövda2 = förälder2InkomstDagar;
+        weeks2 = Math.floor(totalDagarBehövda2 / dagarPerVecka2) || 1;
+    }
+
     // Step 1: Allocate for Parent 1
     if (weeks1 > 0) {
-        const maxDagarPerVecka = deltid === "ja" ? 5 : 7;
-        dagarPerVecka1 = strategy === "maximize" ? maxDagarPerVecka : 1;
         inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
         inkomst2Result = arbetsInkomst2;
         kombineradInkomst = inkomst1Result + inkomst2Result;
@@ -122,43 +148,14 @@ export function optimizeParentalLeave(preferences, inputs) {
                 genomförbarhet.ärGenomförbar = false;
                 genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
             }
-        } else if (strategy === "maximize") {
-            dagarPerVecka1 = maxDagarPerVecka;
-            inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
-            kombineradInkomst = inkomst1Result + inkomst2Result;
-            if (kombineradInkomst < minInkomst) {
-                genomförbarhet.ärGenomförbar = false;
-                genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
-            }
+        } else if (kombineradInkomst < minInkomst) {
+            genomförbarhet.ärGenomförbar = false;
+            genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
         }
-
-        let totalDagarBehövda1 = weeks1 * dagarPerVecka1;
-        let maxDagar1 = förälder1InkomstDagar;
-
-        if (totalDagarBehövda1 > maxDagar1 && inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
-            const bristDagar1 = totalDagarBehövda1 - maxDagar1;
-            const minDagarBehövda2 = weeks2 * Math.min(dagarPerVecka2 || 1, maxDagarPerVecka);
-            const överförbaraDagar2 = Math.max(0, förälder2InkomstDagar - 90 - minDagarBehövda2 - 10);
-            const överförDagar = Math.min(överförbaraDagar2, bristDagar1);
-            förälder2InkomstDagar -= överförDagar;
-            förälder1InkomstDagar += överförDagar;
-            maxDagar1 += överförDagar;
-            genomförbarhet.transferredDays += överförDagar;
-        }
-
-        if (totalDagarBehövda1 > maxDagar1) {
-            totalDagarBehövda1 = maxDagar1;
-            weeks1 = Math.floor(totalDagarBehövda1 / dagarPerVecka1) || 1;
-        }
-
-        inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
-        kombineradInkomst = inkomst1Result + inkomst2Result;
     }
 
     // Step 2: Allocate for Parent 2
     if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && weeks2 > 0) {
-        const maxDagarPerVecka = deltid === "ja" ? 5 : 7;
-        dagarPerVecka2 = strategy === "maximize" ? maxDagarPerVecka : 1;
         inkomst1Result = arbetsInkomst1;
         inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
         kombineradInkomst = inkomst1Result + inkomst2Result;
@@ -173,26 +170,10 @@ export function optimizeParentalLeave(preferences, inputs) {
                 genomförbarhet.ärGenomförbar = false;
                 genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
             }
-        } else if (strategy === "maximize") {
-            dagarPerVecka2 = maxDagarPerVecka;
-            inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
-            kombineradInkomst = inkomst1Result + inkomst2Result;
-            if (kombineradInkomst < minInkomst) {
-                genomförbarhet.ärGenomförbar = false;
-                genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
-            }
+        } else if (kombineradInkomst < minInkomst) {
+            genomförbarhet.ärGenomförbar = false;
+            genomförbarhet.meddelande = `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
         }
-
-        let totalDagarBehövda2 = weeks2 * dagarPerVecka2;
-        let maxDagar2 = förälder2InkomstDagar;
-
-        if (totalDagarBehövda2 > maxDagar2) {
-            totalDagarBehövda2 = maxDagar2;
-            weeks2 = Math.floor(totalDagarBehövda2 / dagarPerVecka2) || 1;
-        }
-
-        inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
-        kombineradInkomst = inkomst1Result + inkomst2Result;
     }
 
     // Step 3: Allocate days for Period 1 (Förälder 1)
@@ -301,6 +282,26 @@ export function optimizeParentalLeave(preferences, inputs) {
             användaMinDagar2 += remainingOverlapDays;
             förälder2MinDagar -= remainingOverlapDays;
         }
+    }
+
+    const phase1Incomes = [];
+    if (plan1.weeks > 0) phase1Incomes.push(plan1.inkomst + arbetsInkomst2);
+    if (plan1NoExtra.weeks > 0) phase1Incomes.push(plan1NoExtra.inkomst + arbetsInkomst2);
+    if (plan1MinDagar.weeks > 0) phase1Incomes.push(plan1MinDagar.inkomst + arbetsInkomst2);
+    const phase2Incomes = [];
+    if (plan2.weeks > 0) phase2Incomes.push(plan2.inkomst + arbetsInkomst1);
+    if (plan2NoExtra.weeks > 0) phase2Incomes.push(plan2NoExtra.inkomst + arbetsInkomst1);
+    if (plan2MinDagar.weeks > 0) phase2Incomes.push(plan2MinDagar.inkomst + arbetsInkomst1);
+
+    const minPhase1 = phase1Incomes.length ? Math.min(...phase1Incomes) : null;
+    const minPhase2 = phase2Incomes.length ? Math.min(...phase2Incomes) : null;
+
+    if (minPhase1 !== null && minPhase1 < minInkomst) {
+        genomförbarhet.ärGenomförbar = false;
+        genomförbarhet.meddelande = `Kombinerad inkomst ${minPhase1.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
+    } else if (minPhase2 !== null && minPhase2 < minInkomst) {
+        genomförbarhet.ärGenomförbar = false;
+        genomförbarhet.meddelande = `Kombinerad inkomst ${minPhase2.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad.`;
     }
 
     return {

--- a/static/script.js
+++ b/static/script.js
@@ -305,8 +305,8 @@ function setupDropdownListeners() {
         const inputs = {
             inkomst1: Number(inkomst1),
             inkomst2: Number(inkomst2),
-            avtal1: avtal1 === "ja",
-            avtal2: avtal2 === "ja",
+            avtal1: avtal1,
+            avtal2: avtal2,
             vårdnad: vårdnad,
             beräknaPartner: beräknaPartner,
             barnbidragPerPerson: barnbidragPerPerson || 1250,
@@ -408,9 +408,9 @@ function optimizeParentalLeave(preferences, inputs) {
     }
 
     const dag1 = beräknaDaglig(inkomst1);
-    const extra1 = inputs.avtal1 ? (inkomst1 <= 49000 ? Math.round(inkomst1 * 0.10) : 4900) : 0;
+    const extra1 = inputs.avtal1 === "ja" ? (inkomst1 <= 49000 ? Math.round(inkomst1 * 0.10) : 4900) : 0;
     const dag2 = inkomst2 > 0 ? beräknaDaglig(inkomst2) : 0;
-    const extra2 = inputs.avtal2 ? (inkomst2 <= 49000 ? Math.round(inkomst2 * 0.10) : 4900) : 0;
+    const extra2 = inputs.avtal2 === "ja" ? (inkomst2 <= 49000 ? Math.round(inkomst2 * 0.10) : 4900) : 0;
 
     let förälder1InkomstDagar = inputs.vårdnad === "ensam" ? 390 : 195;
     let förälder2InkomstDagar = inputs.vårdnad === "ensam" ? 0 : 195;
@@ -1317,18 +1317,18 @@ document.addEventListener("DOMContentLoaded", function () {
         output += `<div class="result-block"><h2>Sammanlagt barnbidrag</h2><p>${details}</p></div>`;
     
         const dag1 = beräknaDaglig(inputs.inkomst1);
-        const extra1 = inputs.avtal1 ? (inputs.inkomst1 <= 49000 ? Math.round(inputs.inkomst1 * 0.10) : 4900) : 0;
+        const extra1 = inputs.avtal1 === "ja" ? (inputs.inkomst1 <= 49000 ? Math.round(inputs.inkomst1 * 0.10) : 4900) : 0;
         const månadsinkomst1 = Math.round((dag1 * 7 * 4.3) / 100) * 100;
         console.log("Form submission - dag1:", dag1, "extra1:", extra1, "månadsinkomst1:", månadsinkomst1);
-        output += generateParentSection(1, dag1, extra1, månadsinkomst1, dagar, inputs.avtal1, barnbidragPerPerson, tilläggPerPerson, inputs.vårdnad === "ensam");
+        output += generateParentSection(1, dag1, extra1, månadsinkomst1, dagar, inputs.avtal1 === "ja", barnbidragPerPerson, tilläggPerPerson, inputs.vårdnad === "ensam");
     
         let dag2 = 0, extra2 = 0, månadsinkomst2 = 0;
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && inputs.inkomst2 > 0) {
             dag2 = beräknaDaglig(inputs.inkomst2);
-            extra2 = inputs.avtal2 ? (inputs.inkomst2 <= 49000 ? Math.round(inputs.inkomst2 * 0.10) : 4900) : 0;
+            extra2 = inputs.avtal2 === "ja" ? (inputs.inkomst2 <= 49000 ? Math.round(inputs.inkomst2 * 0.10) : 4900) : 0;
             månadsinkomst2 = Math.round((dag2 * 7 * 4.3) / 100) * 100;
             console.log("Form submission - dag2:", dag2, "extra2:", extra2, "månadsinkomst2:", månadsinkomst2);
-            output += generateParentSection(2, dag2, extra2, månadsinkomst2, dagar, inputs.avtal2, barnbidragPerPerson, tilläggPerPerson, false);
+            output += generateParentSection(2, dag2, extra2, månadsinkomst2, dagar, inputs.avtal2 === "ja", barnbidragPerPerson, tilläggPerPerson, false);
         }
     
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
@@ -1343,7 +1343,7 @@ document.addEventListener("DOMContentLoaded", function () {
                                 <span>Föräldrapenning (<span class="days-selected-1">${initialDays}</span> dagar/vecka)</span>
                                 <span class="fp-value">${månadsinkomst1.toLocaleString()} kr/månad</span>
                             </div>
-                            ${inputs.avtal1 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra1.toLocaleString()} kr/månad</span></div>` : ''}
+                            ${inputs.avtal1 === "ja" ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra1.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
                             <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tillägg.toLocaleString()} kr/månad</span></div>
                         </div>
@@ -1354,7 +1354,7 @@ document.addEventListener("DOMContentLoaded", function () {
                                 <span>Föräldrapenning (<span class="days-selected-2">${initialDays}</span> dagar/vecka)</span>
                                 <span class="fp-value">${månadsinkomst2.toLocaleString()} kr/månad</span>
                             </div>
-                            ${inputs.avtal2 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra2.toLocaleString()} kr/månad</span></div>` : ''}
+                            ${inputs.avtal2 === "ja" ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra2.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
                             <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tillägg.toLocaleString()} kr/månad</span></div>
                         </div>` : ''}

--- a/templates/script.js
+++ b/templates/script.js
@@ -408,9 +408,9 @@ function optimizeParentalLeave(preferences, inputs) {
     }
 
     const dag1 = beräknaDaglig(inkomst1);
-    const extra1 = inputs.avtal1 ? (inkomst1 <= 49000 ? Math.round(inkomst1 * 0.10) : 4900) : 0;
+    const extra1 = inputs.avtal1 === "ja" ? (inkomst1 <= 49000 ? Math.round(inkomst1 * 0.10) : 4900) : 0;
     const dag2 = inkomst2 > 0 ? beräknaDaglig(inkomst2) : 0;
-    const extra2 = inputs.avtal2 ? (inkomst2 <= 49000 ? Math.round(inkomst2 * 0.10) : 4900) : 0;
+    const extra2 = inputs.avtal2 === "ja" ? (inkomst2 <= 49000 ? Math.round(inkomst2 * 0.10) : 4900) : 0;
 
     let förälder1InkomstDagar = inputs.vårdnad === "ensam" ? 390 : 195;
     let förälder2InkomstDagar = inputs.vårdnad === "ensam" ? 0 : 195;
@@ -1284,10 +1284,10 @@ document.addEventListener("DOMContentLoaded", function () {
         const inputs = {
             vårdnad: elements.vårdnadInput.value || "gemensam",
             inkomst1: parseFloat(elements.inkomst1.value) || 0,
-            avtal1: elements.avtal1.value === 'ja',
+            avtal1: elements.avtal1.value || 'nej',
             beräknaPartner: elements.partnerInput.value || "ja",
             inkomst2: parseFloat(elements.inkomst2?.value) || 35000, // Default to 35000
-            avtal2: elements.avtal2 ? elements.avtal2.value === 'ja' : false,
+            avtal2: elements.avtal2 ? elements.avtal2.value || 'nej' : 'nej',
             children: parseInt(elements.children.value) || 0,
             plannedChildren: parseInt(elements.plannedChildren.value) || 0,
             barnbidragPerPerson,
@@ -1317,18 +1317,18 @@ document.addEventListener("DOMContentLoaded", function () {
         output += `<div class="result-block"><h2>Sammanlagt barnbidrag</h2><p>${details}</p></div>`;
     
         const dag1 = beräknaDaglig(inputs.inkomst1);
-        const extra1 = inputs.avtal1 ? (inputs.inkomst1 <= 49000 ? Math.round(inputs.inkomst1 * 0.10) : 4900) : 0;
+        const extra1 = inputs.avtal1 === "ja" ? (inputs.inkomst1 <= 49000 ? Math.round(inputs.inkomst1 * 0.10) : 4900) : 0;
         const månadsinkomst1 = Math.round((dag1 * 7 * 4.3) / 100) * 100;
         console.log("Form submission - dag1:", dag1, "extra1:", extra1, "månadsinkomst1:", månadsinkomst1);
-        output += generateParentSection(1, dag1, extra1, månadsinkomst1, dagar, inputs.avtal1, barnbidragPerPerson, tilläggPerPerson, inputs.vårdnad === "ensam");
+        output += generateParentSection(1, dag1, extra1, månadsinkomst1, dagar, inputs.avtal1 === "ja", barnbidragPerPerson, tilläggPerPerson, inputs.vårdnad === "ensam");
     
         let dag2 = 0, extra2 = 0, månadsinkomst2 = 0;
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && inputs.inkomst2 > 0) {
             dag2 = beräknaDaglig(inputs.inkomst2);
-            extra2 = inputs.avtal2 ? (inputs.inkomst2 <= 49000 ? Math.round(inputs.inkomst2 * 0.10) : 4900) : 0;
+            extra2 = inputs.avtal2 === "ja" ? (inputs.inkomst2 <= 49000 ? Math.round(inputs.inkomst2 * 0.10) : 4900) : 0;
             månadsinkomst2 = Math.round((dag2 * 7 * 4.3) / 100) * 100;
             console.log("Form submission - dag2:", dag2, "extra2:", extra2, "månadsinkomst2:", månadsinkomst2);
-            output += generateParentSection(2, dag2, extra2, månadsinkomst2, dagar, inputs.avtal2, barnbidragPerPerson, tilläggPerPerson, false);
+            output += generateParentSection(2, dag2, extra2, månadsinkomst2, dagar, inputs.avtal2 === "ja", barnbidragPerPerson, tilläggPerPerson, false);
         }
     
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
@@ -1343,7 +1343,7 @@ document.addEventListener("DOMContentLoaded", function () {
                                 <span>Föräldrapenning (<span class="days-selected-1">${initialDays}</span> dagar/vecka)</span>
                                 <span class="fp-value">${månadsinkomst1.toLocaleString()} kr/månad</span>
                             </div>
-                            ${inputs.avtal1 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra1.toLocaleString()} kr/månad</span></div>` : ''}
+                            ${inputs.avtal1 === "ja" ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra1.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
                             <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tilläggPerPerson.toLocaleString()} kr/månad</span></div>
                         </div>
@@ -1354,7 +1354,7 @@ document.addEventListener("DOMContentLoaded", function () {
                                 <span>Föräldrapenning (<span class="days-selected-2">${initialDays}</span> dagar/vecka)</span>
                                 <span class="fp-value">${månadsinkomst2.toLocaleString()} kr/månad</span>
                             </div>
-                            ${inputs.avtal2 ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra2.toLocaleString()} kr/månad</span></div>` : ''}
+                            ${inputs.avtal2 === "ja" ? `<div class="monthly-row extra-row"><span>Föräldralön</span><span class="extra-value">${extra2.toLocaleString()} kr/månad</span></div>` : ''}
                             <div class="monthly-row barnbidrag-row"><span>Barnbidrag</span><span class="barnbidrag-value">${barnbidragPerPerson.toLocaleString()} kr/månad</span></div>
                             <div class="monthly-row tillagg-row"><span>Flerbarnstillägg</span><span class="tillagg-value">${tilläggPerPerson.toLocaleString()} kr/månad</span></div>
                         </div>` : ''}


### PR DESCRIPTION
## Summary
- Reserve both parents' requested leave before transferring days and recompute final feasibility
- Only apply parental supplement when `"ja"` is selected and pass union status as strings in the UI
- Mirror logic in template files for consistent calculations and output

## Testing
- `node --check static/calculations.js`
- `node --check templates/calculations.js`
- `node --check static/script.js`
- `node --check templates/script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b141deef18832bbb0f38b765586c25