### PR TITLE
Enable progress bar step navigation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -616,6 +616,8 @@ input[type="number"] {
     text-align: center;
     flex: 1;
     color: #ccc; /* Unreached steps remain gray */
+    cursor: pointer;
+    pointer-events: auto;
 }
 
 #progress-bar .step::before {
@@ -659,7 +661,6 @@ input[type="number"] {
 /* Skipped state */
 #progress-bar .step.skipped {
     color: #ddd;
-    pointer-events: none;
 }
 
 #progress-bar .step.skipped::before {

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -92,9 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const stepNum = i + 1;
             const nextIndex = stepToIndex[stepNum];
             if (nextIndex === undefined || nextIndex === currentIndex) return;
-            history.push(currentIndex);
-            currentIndex = nextIndex;
-            showCurrent();
+            goTo(nextIndex);
         });
     });
 


### PR DESCRIPTION
## Summary
- Make all progress bar steps clickable regardless of completion
- Route progress bar clicks through wizard navigation logic for consistent history handling

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1242d6c832b889b8f6d81956b90