### PR TITLE
Fix parental leave week segmentation when no employer pay

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -276,7 +276,7 @@ export function optimizeParentalLeave(preferences, inputs) {
         const plan1ExtraWeeks = weeks1;
         plan1 = {
             startWeek: 0,
-            weeks: weeks1 + weeks1NoExtra,
+            weeks: weeks1,
             dagarPerVecka: dagarPerVecka1,
             inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg)),
             inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, 0, barnbidrag, tillägg)),
@@ -329,7 +329,7 @@ export function optimizeParentalLeave(preferences, inputs) {
         const plan2ExtraWeeks = weeks2;
         plan2 = {
             startWeek: weeks1 + weeks1NoExtra,
-            weeks: weeks2 + weeks2NoExtra,
+            weeks: weeks2,
             dagarPerVecka: dagarPerVecka2,
             inkomst: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg)),
             inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, 0, barnbidrag, tillägg)),

--- a/static/chart.js
+++ b/static/chart.js
@@ -95,10 +95,10 @@ export function renderGanttChart(
     summaryBox.style.overflowY = 'auto'; // Scroll if content overflows
     summaryBox.innerHTML = '<p>Hovra över en punkt för att se detaljer.</p>';
 
-    const period1ExtraWeeks = Math.max((plan1.weeks || 0) - (plan1NoExtra.weeks || 0), 0);
+    const period1ExtraWeeks = plan1.weeks || 0;
     const period1NoExtraWeeks = plan1NoExtra.weeks || 0;
     const period1MinWeeks = plan1MinDagar.weeks || 0;
-    const period2ExtraWeeks = Math.max((plan2.weeks || 0) - (plan2NoExtra.weeks || 0), 0);
+    const period2ExtraWeeks = plan2.weeks || 0;
     const period2NoExtraWeeks = plan2NoExtra.weeks || 0;
     const period2MinWeeks = plan2MinDagar.weeks || 0;
     const period1OverlapWeeks = plan1Overlap.weeks || 0;

--- a/static/script.js
+++ b/static/script.js
@@ -548,7 +548,7 @@ function optimizeParentalLeave(preferences, inputs) {
 
         plan1 = {
             startWeek: 0,
-            weeks: weeks1 + weeks1NoExtra,
+            weeks: weeks1,
             dagarPerVecka: dagarPerVecka1,
             inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg)),
             inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, 0, barnbidrag, tillägg)),
@@ -602,7 +602,7 @@ function optimizeParentalLeave(preferences, inputs) {
 
         plan2 = {
             startWeek: weeks1 + weeks1NoExtra,
-            weeks: weeks2 + weeks2NoExtra,
+            weeks: weeks2,
             dagarPerVecka: dagarPerVecka2,
             inkomst: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg)),
             inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, 0, barnbidrag, tillägg)),


### PR DESCRIPTION
## Summary
- Exclude non-supplement weeks from employer-paid leave segments
- Read chart data directly from segment weeks for accurate visualization
- Align legacy script logic with new week segmentation rules

## Testing
- `python -m py_compile app.py`
- `node --check static/calculations.js`
- `node --check static/chart.js`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b23443ce7c832ba86f99fbbc9857bc