### PR TITLE
Handle avtal flags as strings for parental salary

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -107,15 +107,17 @@ export function optimizeParentalLeave(preferences, inputs) {
 
     const anst1 = inputs.anställningstid1 || "";
     const anst2 = inputs.anställningstid2 || "";
+    const avtal1Ja = inputs.avtal1 === "ja" || inputs.avtal1 === true;
+    const avtal2Ja = inputs.avtal2 === "ja" || inputs.avtal2 === true;
     const dag1 = beräknaDaglig(inkomst1);
-    const extra1 = inputs.avtal1 === "ja" && anst1 !== "0-5" ? beräknaFöräldralön(inkomst1) : 0;
+    const extra1 = avtal1Ja && anst1 !== "0-5" ? beräknaFöräldralön(inkomst1) : 0;
     const dag2 = inkomst2 > 0 ? beräknaDaglig(inkomst2) : 0;
-    const extra2 = inputs.avtal2 === "ja" && anst2 !== "0-5" ? beräknaFöräldralön(inkomst2) : 0;
+    const extra2 = avtal2Ja && anst2 !== "0-5" ? beräknaFöräldralön(inkomst2) : 0;
 
-    const maxFöräldralönWeeks1 = inputs.avtal1 === "ja"
+    const maxFöräldralönWeeks1 = avtal1Ja
         ? anst1 === "6-12" ? 2 * 4.3 : anst1 === ">1" ? 6 * 4.3 : 0
         : 0;
-    const maxFöräldralönWeeks2 = inputs.avtal2 === "ja"
+    const maxFöräldralönWeeks2 = avtal2Ja
         ? anst2 === "6-12" ? 2 * 4.3 : anst2 === ">1" ? 6 * 4.3 : 0
         : 0;
     let unusedFöräldralönWeeks1 = 0;

--- a/static/index.js
+++ b/static/index.js
@@ -216,8 +216,8 @@ function handleOptimize() {
     const inputs = {
         inkomst1: window.appState.inkomst1,
         inkomst2: window.appState.inkomst2,
-        avtal1: window.appState.avtal1,
-        avtal2: window.appState.avtal2,
+        avtal1: window.appState.avtal1 ? 'ja' : 'nej',
+        avtal2: window.appState.avtal2 ? 'ja' : 'nej',
         anställningstid1: window.appState.anställningstid1,
         anställningstid2: window.appState.anställningstid2,
         vårdnad: window.appState.vårdnad,


### PR DESCRIPTION
## Summary
- Send `avtal1` and `avtal2` to optimization as `'ja'`/`'nej'` strings rather than booleans.
- Accept both string and boolean inputs when calculating extra parental salary and maximum föräldralön weeks.

## Testing
- `node --input-type=module <<'NODE' ... NODE`
- `node --input-type=module <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b555e0cf7c832b93fb1eb16466197b