### PR TITLE
Ensure föräldralön applies only at full weeks and surface infeasible plans

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -416,27 +416,32 @@ export function renderGanttChart(
             <span style="color: #f28c38;">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
         `;
     }
+    if (!genomförbarhet.ärGenomförbar && genomförbarhet.meddelande) {
+        meddelandeHtml += `
+            <span style="color: #ff0000;">${genomförbarhet.meddelande}</span><br><br>
+        `;
+    }
 
     meddelandeHtml += `
         <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
         Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-        Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad.<br>
-        Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad.<br>
+        Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).<br>
+        Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).<br>
         <strong>Kombinerad inkomst: ${(dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst).toLocaleString()} kr/månad</strong><br><br>
 
         <strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1End)}</i>)</strong><br>
-        Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.<br>
+        Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).<br>
         Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.<br>
         <strong>Kombinerad inkomst: ${period1KombExtra.toLocaleString()} kr/månad</strong><br>
-        ${period1NoExtraWeeks > 0 ? `Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad. <strong>Kombinerad inkomst: ${period1KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
-        ${period1MinWeeks > 0 ? `Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad. <strong>Kombinerad inkomst: ${period1KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${period1NoExtraWeeks > 0 ? `Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka). <strong>Kombinerad inkomst: ${period1KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
+        ${period1MinWeeks > 0 ? `Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka). <strong>Kombinerad inkomst: ${period1KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
 
         <strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2Start)} till ${formatDate(period2End)}</i>)</strong><br>
-        Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.<br>
+        Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).<br>
         Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.<br>
         <strong>Kombinerad inkomst: ${period2KombExtra.toLocaleString()} kr/månad</strong><br>
-        ${period2NoExtraWeeks > 0 ? `Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad. <strong>Kombinerad inkomst: ${period2KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
-        ${period2MinWeeks > 0 ? `Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad. <strong>Kombinerad inkomst: ${period2KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${period2NoExtraWeeks > 0 ? `Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka). <strong>Kombinerad inkomst: ${period2KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
+        ${period2MinWeeks > 0 ? `Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka). <strong>Kombinerad inkomst: ${period2KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
 
         <strong>Återstående dagar:</strong><br>
         Förälder 1: ${förälder1InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder1MinDagar.toLocaleString()} dagar (lägstanivå)<br>

--- a/static/index.js
+++ b/static/index.js
@@ -237,12 +237,13 @@ function handleOptimize() {
     try {
         const result = optimizeParentalLeave(preferences, inputs);
 
-        // Validate leave duration
+        // Validate leave duration and show message but continue rendering chart
+        const err = document.getElementById('leave-duration-error');
         if (!result.genomförbarhet.ärGenomförbar) {
-            const err = document.getElementById('leave-duration-error');
             err.textContent = result.genomförbarhet.meddelande;
             err.style.display = 'block';
-            return;
+        } else {
+            err.style.display = 'none';
         }
 
         // `användaInkomstDagar` already accounts for both periods with and without
@@ -258,13 +259,10 @@ function handleOptimize() {
         const maxDays1 = förälder1InkomstDagar + förälder1MinDagar + transferred;
         const maxDays2 = förälder2InkomstDagar + förälder2MinDagar - transferred;
 
-        const errorElement = document.getElementById('leave-duration-error');
         if (totalDays1 > maxDays1 || totalDays2 > maxDays2) {
-            errorElement.style.display = 'block';
+            err.style.display = 'block';
             return;
         }
-
-        errorElement.style.display = 'none';
 
         // Render Gantt chart
         document.getElementById('optimization-result').style.display = 'block';


### PR DESCRIPTION
## Summary
- Only grant föräldralön when 7 days per week are taken and attempt to use all available days before failing minimum income checks
- Render optimization chart even when income goals aren't met and show specific failure messages with days-per-week details
- Include days-per-week context in chart summaries and handle avtal flags consistently as strings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -e "import('./static/calculations.js').then(m=>{const prefs={deltid:'nej',ledigTid1:6,ledigTid2:0,minInkomst:70000,strategy:'longer'}; const inputs={inkomst1:50000,inkomst2:0,avtal1:'ja',avtal2:'nej',anställningstid1:'>1',anställningstid2:'',vårdnad:'ensam',beräknaPartner:'nej',barnbidragPerPerson:625,tilläggPerPerson:0,barnDatum:'2025-01-01'}; console.log(m.optimizeParentalLeave(prefs,inputs));});"

------
https://chatgpt.com/codex/tasks/task_e_68b54e315590832bbe43f52e56ceaa91