### PR TITLE
Add tax rate input and net income display

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -59,6 +59,18 @@ export function beräknaFöräldralön(inkomst) {
 }
 
 /**
+ * Calculate net monthly income from gross and tax rate
+ * @param {number} inkomst - Gross monthly income
+ * @param {number} skattesats - Tax rate percentage
+ * @returns {number} Net monthly income
+ */
+export function beräknaNetto(inkomst, skattesats) {
+    if (!inkomst || inkomst <= 0) return 0;
+    const rate = skattesats > 0 ? skattesats / 100 : 0;
+    return Math.round(inkomst * (1 - rate));
+}
+
+/**
  * Calculate child allowance and additional benefits
  * @param {number} totalBarn - Total number of children
  * @param {boolean} ensamVårdnad - True if sole custody

--- a/static/index.js
+++ b/static/index.js
@@ -11,7 +11,8 @@ import {
     beräknaDaglig,
     beräknaBarnbidrag,
     optimizeParentalLeave,
-    beräknaFöräldralön
+    beräknaFöräldralön,
+    beräknaNetto
 } from './calculations.js';
 import {
     updateProgress, setupInfoBoxToggle,
@@ -69,6 +70,7 @@ function handleFormSubmit(e) {
     // Collect form inputs
     const inkomst1 = parseFloat(document.getElementById('inkomst1').value) || 0;
     const inkomst2 = parseFloat(document.getElementById('inkomst2').value) || 0;
+    const skattesats = parseFloat(document.getElementById('skattesats').value) || 0;
     const vårdnad = document.getElementById('vårdnad').value || 'gemensam';
     const beräknaPartner = document.getElementById('beräkna-partner').value || 'ja';
     const barnTidigare = parseInt(document.getElementById('barn-tidigare').value) || 0;
@@ -95,6 +97,8 @@ function handleFormSubmit(e) {
     const extra1 = avtal1 === 'ja' && anst1 !== '0-5' ? beräknaFöräldralön(inkomst1) : 0;
     const dag2 = beräknaPartner === 'ja' && vårdnad === 'gemensam' ? beräknaDaglig(inkomst2) : 0;
     const extra2 = avtal2 === 'ja' && anst2 !== '0-5' && beräknaPartner === 'ja' ? beräknaFöräldralön(inkomst2) : 0;
+    const netto1 = beräknaNetto(inkomst1, skattesats);
+    const netto2 = beräknaNetto(inkomst2, skattesats);
 
     // Generate results
     const resultBlock = document.getElementById('result-block');
@@ -104,8 +108,9 @@ function handleFormSubmit(e) {
     const månadsinkomst1 = Math.round((dag1 * 7 * 4.3) / 100) * 100;
         resultHtml += generateParentSection(
             1, dag1, extra1, månadsinkomst1, förälder1InkomstDagar,
-            avtal1 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg,
-            vårdnad === 'ensam', inkomst1
+            avtal1 === 'ja', barnbidragResult.barnbidrag,
+            barnbidragResult.tillägg, vårdnad === 'ensam',
+            inkomst1, netto1
         );
 
     // Parent 2 results (if applicable)
@@ -113,8 +118,8 @@ function handleFormSubmit(e) {
         const månadsinkomst2 = Math.round((dag2 * 7 * 4.3) / 100) * 100;
         resultHtml += generateParentSection(
             2, dag2, extra2, månadsinkomst2, förälder2InkomstDagar,
-            avtal2 === 'ja', barnbidragResult.barnbidrag, barnbidragResult.tillägg,
-            false, inkomst2
+            avtal2 === 'ja', barnbidragResult.barnbidrag,
+            barnbidragResult.tillägg, false, inkomst2, netto2
         );
     }
 
@@ -129,12 +134,23 @@ function handleFormSubmit(e) {
 
     // Store global state for optimization
     window.appState = {
-        inkomst1, inkomst2, vårdnad, beräknaPartner,
+        inkomst1,
+        inkomst2,
+        skattesats,
+        netto1,
+        netto2,
+        vårdnad,
+        beräknaPartner,
         barnbidragPerPerson: barnbidragResult.barnbidrag,
         tilläggPerPerson: barnbidragResult.tillägg,
-        dag1, extra1, dag2, extra2,
-        avtal1: avtal1 === 'ja', avtal2: avtal2 === 'ja',
-        anställningstid1: anst1, anställningstid2: anst2
+        dag1,
+        extra1,
+        dag2,
+        extra2,
+        avtal1: avtal1 === 'ja',
+        avtal2: avtal2 === 'ja',
+        anställningstid1: anst1,
+        anställningstid2: anst2
     };
 
     const leaveContainer = document.getElementById('leave-slider-container');

--- a/static/ui.js
+++ b/static/ui.js
@@ -104,9 +104,11 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
  * @param {number} tillägg - Additional child allowance
  * @param {boolean} ärEnsam - True if sole custody
  * @param {number} inkomst - Reported salary
+ * @param {number} netto - Net salary after tax
  * @returns {string} HTML section string
 */
-export function generateParentSection(parentNum, dag, extra, månadsinkomst, dagar, avtal, barnbidrag, tillägg, ärEnsam, inkomst) {
+export function generateParentSection(parentNum, dag, extra, månadsinkomst,
+    dagar, avtal, barnbidrag, tillägg, ärEnsam, inkomst, netto) {
     const lagstanivådagar = Math.round(dagar * 0.23076923);
     const gemensamDetails = `
         <div class="benefit-details">
@@ -138,9 +140,13 @@ export function generateParentSection(parentNum, dag, extra, månadsinkomst, dag
                     </div>
                 </div>
                 <div class="benefit-card">
-                    <div class="benefit-title">Månadsinkomst</div>
+                    <div class="benefit-title">Bruttoinkomst</div>
                     <div class="benefit-value-large">
                         <span>${inkomst.toLocaleString()}</span><span class="unit">kr/månad</span>
+                    </div>
+                    <div class="benefit-title" style="margin-top: 0.5rem;">Nettoinkomst</div>
+                    <div class="benefit-value-large">
+                        <span>${netto.toLocaleString()}</span><span class="unit">kr/månad</span>
                     </div>
                     <div class="benefit-title" style="margin-top: 0.5rem;">Preliminär föräldralön</div>
                     <div class="benefit-value-large">

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,6 +102,9 @@
                     </div>
                     <input type="hidden" name="anstallningstid_1" id="anstallningstid-1" value="">
                 </div>
+                <div class="question-icon"><i class="fa-solid fa-percent"></i></div>
+                <label for="skattesats">Kommunalskatt (%)</label>
+                <input type="number" name="skattesats" id="skattesats" placeholder="30" min="0" max="100">
             </div>
 
             <div id="inkomst-block-2" class="form-section wizard-step">


### PR DESCRIPTION
## Summary
- collect tax rate from user and compute net salaries
- add helper to convert gross salary to net given tax rate
- show both brutto- and nettoinkomst in results

## Testing
- `node --check static/calculations.js`
- `node --check static/index.js`
- `node --check static/ui.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9cbc6c8832bb4744f4b907c2c75