### PR TITLE
Refine parental benefit totals and dynamic extra pay

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -108,7 +108,7 @@ function handleFormSubmit(e) {
             1, dag1, extra1, månadsinkomst1, förälder1InkomstDagar,
             avtal1 === 'ja', barnbidragResult.barnbidrag,
             barnbidragResult.tillägg, vårdnad === 'ensam',
-            inkomst1, netto1
+            inkomst1
         );
 
     // Parent 2 results (if applicable)
@@ -117,7 +117,7 @@ function handleFormSubmit(e) {
         resultHtml += generateParentSection(
             2, dag2, extra2, månadsinkomst2, förälder2InkomstDagar,
             avtal2 === 'ja', barnbidragResult.barnbidrag,
-            barnbidragResult.tillägg, false, inkomst2, netto2
+            barnbidragResult.tillägg, false, inkomst2
         );
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -541,6 +541,11 @@ input[type="number"] {
     font-weight: 600;
 }
 
+.fp-brutto {
+    color: #999;
+    font-weight: 400;
+}
+
 .fp-row {
     background-color: #f5f2eb; /* Subtle beige for Föräldrapenning */
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- remove nettoinkomst from benefit cards
- show parental benefit after tax and compute totals from it
- scale and update extra parental pay based on selected days per week

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7f157ef88832b95f150463b9316df