### PR TITLE
Add parental pay maximization workflow

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -98,18 +98,27 @@ export function beräknaBarnbidrag(totalBarn, ensamVårdnad) {
  * @returns {Object} Optimized leave plans and related data
  */
 export function optimizeParentalLeave(preferences, inputs) {
-    const { deltid, ledigTid1, ledigTid2 = 0, minInkomst, strategy } = preferences;
+    const {
+        deltid,
+        ledigTid1,
+        ledigTid2 = 0,
+        minInkomst,
+        strategy,
+        maximizeFöräldralön = false
+    } = preferences;
     let plan1 = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, inkomstUtanExtra: 0, användaInkomstDagar: 0, användaMinDagar: 0 };
     let plan1NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan2 = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, inkomstUtanExtra: 0, användaInkomstDagar: 0, användaMinDagar: 0 };
     let plan2NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan1MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan2MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
-    let plan1Overlap = { startWeek: 0, weeks: 2, dagarPerVecka: 0, inkomst: 0 };
+    let plan1Overlap = { startWeek: 0, weeks: 2, dagarPerVecka: 5, inkomst: 0 };
     let plan1ExtraWeeks = 0;
     let plan1NoExtraWeeksTotal = 0;
     let plan2ExtraWeeks = 0;
     let plan2NoExtraWeeksTotal = 0;
+    let plan1Savings = { total: 0, perMonth: 0, weeks: 0, months: 0 };
+    let plan2Savings = { total: 0, perMonth: 0, weeks: 0, months: 0 };
     let genomförbarhet = {
         ärGenomförbar: true,
         meddelande: "",
@@ -159,6 +168,8 @@ export function optimizeParentalLeave(preferences, inputs) {
 
     let dagarPerVecka1 = 0;
     let dagarPerVecka2 = 0;
+    let plan1OriginalDaysPerWeek = 0;
+    let plan2OriginalDaysPerWeek = 0;
     let weeks1 = Math.round(ledigTid1 * 4.3);
     let weeks2 = Math.round(ledigTid2 * 4.3);
     let inkomst1Result = arbetsInkomst1;
@@ -323,6 +334,7 @@ export function optimizeParentalLeave(preferences, inputs) {
             användaInkomstDagar: användaInkomstDagar1,
             användaMinDagar: användaMinDagar1
         };
+        plan1OriginalDaysPerWeek = plan1.dagarPerVecka;
 
         plan1NoExtra = {
             startWeek: plan1ExtraWeeks,
@@ -406,11 +418,12 @@ export function optimizeParentalLeave(preferences, inputs) {
         };
 
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
+            const overlapDaysPerWeek = 5;
             plan1Overlap = {
                 startWeek: 0,
                 weeks: 2,
-                dagarPerVecka: dagarPerVecka1,
-                inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg))
+                dagarPerVecka: overlapDaysPerWeek,
+                inkomst: Math.round(beräknaMånadsinkomst(dag1, overlapDaysPerWeek, extra1, barnbidrag, tillägg))
             };
         }
         unusedFöräldralönWeeks1 = Math.max(0, maxFöräldralönWeeks1 - plan1ExtraWeeks);
@@ -445,6 +458,7 @@ export function optimizeParentalLeave(preferences, inputs) {
             användaInkomstDagar: användaInkomstDagar2,
             användaMinDagar: användaMinDagar2
         };
+        plan2OriginalDaysPerWeek = plan2.dagarPerVecka;
 
         const plan2StartNoExtra = plan2.startWeek + plan2ExtraWeeks;
         plan2NoExtra = {
@@ -461,6 +475,110 @@ export function optimizeParentalLeave(preferences, inputs) {
             inkomst: Math.round(beräknaMånadsinkomst(MINIMUM_RATE, dagarPerVecka2, 0, barnbidrag, tillägg))
         };
         unusedFöräldralönWeeks2 = Math.max(0, maxFöräldralönWeeks2 - plan2ExtraWeeks);
+    }
+
+    if (
+        maximizeFöräldralön &&
+        plan1.weeks > 0 &&
+        extra1 > 0 &&
+        maxFöräldralönWeeks1 > 0
+    ) {
+        const baselineDaysPerWeek = Math.max(1, plan1OriginalDaysPerWeek || plan1.dagarPerVecka || 1);
+        const targetWeeks = Math.min(plan1.weeks, Math.round(maxFöräldralönWeeks1));
+        const maximizedIncome = Math.round(
+            beräknaMånadsinkomst(dag1, 7, extra1, barnbidrag, tillägg)
+        );
+        const baselineIncome = Math.round(
+            beräknaMånadsinkomst(dag1, baselineDaysPerWeek, extra1, barnbidrag, tillägg)
+        );
+        const additionalDays = Math.max(0, targetWeeks * (7 - baselineDaysPerWeek));
+        if (additionalDays > 0) {
+            plan1.dagarPerVecka = 7;
+            plan1.inkomst = maximizedIncome;
+            plan1.inkomstUtanExtra = Math.round(
+                beräknaMånadsinkomst(dag1, 7, 0, barnbidrag, tillägg)
+            );
+            plan1.användaInkomstDagar += additionalDays;
+            förälder1InkomstDagar = Math.max(0, förälder1InkomstDagar - additionalDays);
+        }
+        const totalSavings = Math.max(0, maximizedIncome - baselineIncome) * (targetWeeks / 4.3);
+        const savingsWeeks = (plan1NoExtra.weeks || 0) + (plan1MinDagar.weeks || 0);
+        const savingsMonths = savingsWeeks / 4.3;
+        const perMonth = savingsMonths > 0 ? Math.round(totalSavings / savingsMonths) : 0;
+        plan1Savings = {
+            total: Math.round(totalSavings),
+            perMonth,
+            weeks: savingsWeeks,
+            months: savingsMonths
+        };
+        if (plan1NoExtra.weeks > 0) {
+            plan1NoExtra.dagarPerVecka = baselineDaysPerWeek;
+            plan1NoExtra.inkomst = Math.round(
+                beräknaMånadsinkomst(dag1, baselineDaysPerWeek, 0, barnbidrag, tillägg)
+            );
+        }
+        if (plan1MinDagar.weeks > 0) {
+            plan1MinDagar.dagarPerVecka = baselineDaysPerWeek;
+            plan1MinDagar.inkomst = Math.round(
+                beräknaMånadsinkomst(MINIMUM_RATE, baselineDaysPerWeek, 0, barnbidrag, tillägg)
+            );
+        }
+        if (perMonth > 0) {
+            plan1NoExtra.savingsPerMonth = perMonth;
+            plan1MinDagar.savingsPerMonth = perMonth;
+        }
+    }
+
+    if (
+        maximizeFöräldralön &&
+        plan2.weeks > 0 &&
+        extra2 > 0 &&
+        maxFöräldralönWeeks2 > 0
+    ) {
+        const baselineDaysPerWeek = Math.max(1, plan2OriginalDaysPerWeek || plan2.dagarPerVecka || 1);
+        const targetWeeks = Math.min(plan2.weeks, Math.round(maxFöräldralönWeeks2));
+        const maximizedIncome = Math.round(
+            beräknaMånadsinkomst(dag2, 7, extra2, barnbidrag, tillägg)
+        );
+        const baselineIncome = Math.round(
+            beräknaMånadsinkomst(dag2, baselineDaysPerWeek, extra2, barnbidrag, tillägg)
+        );
+        const additionalDays = Math.max(0, targetWeeks * (7 - baselineDaysPerWeek));
+        if (additionalDays > 0) {
+            plan2.dagarPerVecka = 7;
+            plan2.inkomst = maximizedIncome;
+            plan2.inkomstUtanExtra = Math.round(
+                beräknaMånadsinkomst(dag2, 7, 0, barnbidrag, tillägg)
+            );
+            plan2.användaInkomstDagar += additionalDays;
+            förälder2InkomstDagar = Math.max(0, förälder2InkomstDagar - additionalDays);
+        }
+        const totalSavings = Math.max(0, maximizedIncome - baselineIncome) * (targetWeeks / 4.3);
+        const savingsWeeks = (plan2NoExtra.weeks || 0) + (plan2MinDagar.weeks || 0);
+        const savingsMonths = savingsWeeks / 4.3;
+        const perMonth = savingsMonths > 0 ? Math.round(totalSavings / savingsMonths) : 0;
+        plan2Savings = {
+            total: Math.round(totalSavings),
+            perMonth,
+            weeks: savingsWeeks,
+            months: savingsMonths
+        };
+        if (plan2NoExtra.weeks > 0) {
+            plan2NoExtra.dagarPerVecka = baselineDaysPerWeek;
+            plan2NoExtra.inkomst = Math.round(
+                beräknaMånadsinkomst(dag2, baselineDaysPerWeek, 0, barnbidrag, tillägg)
+            );
+        }
+        if (plan2MinDagar.weeks > 0) {
+            plan2MinDagar.dagarPerVecka = baselineDaysPerWeek;
+            plan2MinDagar.inkomst = Math.round(
+                beräknaMånadsinkomst(MINIMUM_RATE, baselineDaysPerWeek, 0, barnbidrag, tillägg)
+            );
+        }
+        if (perMonth > 0) {
+            plan2NoExtra.savingsPerMonth = perMonth;
+            plan2MinDagar.savingsPerMonth = perMonth;
+        }
     }
 
     // Step 5: Handle overlap days (10 days for Förälder 2)
@@ -520,6 +638,8 @@ export function optimizeParentalLeave(preferences, inputs) {
         maxFöräldralönWeeks1,
         maxFöräldralönWeeks2,
         unusedFöräldralönWeeks1,
-        unusedFöräldralönWeeks2
+        unusedFöräldralönWeeks2,
+        plan1Savings,
+        plan2Savings
     };
 }

--- a/static/chart.js
+++ b/static/chart.js
@@ -65,7 +65,9 @@ export function renderGanttChart(
     maxFöräldralönWeeks1,
     maxFöräldralönWeeks2,
     unusedFöräldralönWeeks1,
-    unusedFöräldralönWeeks2
+    unusedFöräldralönWeeks2,
+    plan1Savings,
+    plan2Savings
 ) {
     const ganttChart = document.getElementById('gantt-chart');
     if (!ganttChart) {
@@ -107,6 +109,8 @@ export function renderGanttChart(
     const transferredDays = genomförbarhet.transferredDays || 0;
     const transferredWeeks = transferredDays > 0 && plan1.dagarPerVecka > 0 ? Math.ceil(transferredDays / plan1.dagarPerVecka) : 0;
     const transferredStartWeek = transferredWeeks > 0 ? Math.max(0, baseWeeks1 - transferredWeeks) : baseWeeks1;
+    const savingsColor = '#f28c38';
+    const transferredColor = '#c47b34';
 
     let startDate = barnDatum ? new Date(barnDatum) : new Date();
     if (isNaN(startDate.getTime())) {
@@ -133,6 +137,13 @@ export function renderGanttChart(
     period2End.setDate(period2End.getDate() + (period2TotalWeeks * 7) - 1);
 
     const totalaWeeks = Math.max(period1TotalWeeks + period2TotalWeeks, 60);
+
+    const hasSavingsHighlight1 = plan1SavingsPerMonth > 0 && plan1SavingsWeeks > 0;
+    const hasSavingsHighlight2 = plan2SavingsPerMonth > 0 && plan2SavingsWeeks > 0;
+    const savingsHighlightStart1 = period1ExtraWeeks;
+    const savingsHighlightEnd1 = savingsHighlightStart1 + (hasSavingsHighlight1 ? plan1SavingsWeeks : 0);
+    const savingsHighlightStart2 = period1TotalWeeks + period2ExtraWeeks;
+    const savingsHighlightEnd2 = savingsHighlightStart2 + (hasSavingsHighlight2 ? plan2SavingsWeeks : 0);
 
     const weekLabels = [];
     const monthLabels = new Array(totalaWeeks).fill('');
@@ -202,7 +213,12 @@ export function renderGanttChart(
         return enforceMinimum ? safeDagarPerVecka(numeric) : numeric;
     };
 
-    const calculateLeaveComponents = (dailyRate, dagarPerVecka, extraBelopp, { includeBenefits = true, enforceMinimum = false } = {}) => {
+    const calculateLeaveComponents = (
+        dailyRate,
+        dagarPerVecka,
+        extraBelopp,
+        { includeBenefits = true, enforceMinimum = false, savings = 0 } = {}
+    ) => {
         const daysPerWeek = normalizeDaysPerWeek(dagarPerVecka, enforceMinimum);
         const fpGross = Math.round((dailyRate * daysPerWeek * 4.3) / 100) * 100;
         const extraGross = extraBelopp ? Math.round(extraBelopp * (daysPerWeek / 7)) : 0;
@@ -211,7 +227,8 @@ export function renderGanttChart(
             extra: beräknaNetto(extraGross),
             barnbidrag: includeBenefits ? barnbidragPerPerson : 0,
             tillägg: includeBenefits ? tilläggPerPerson : 0,
-            lön: 0
+            lön: 0,
+            sparade: savings
         };
     };
 
@@ -223,7 +240,8 @@ export function renderGanttChart(
             extra: 0,
             barnbidrag: includeBenefits ? barnbidragPerPerson : 0,
             tillägg: includeBenefits ? tilläggPerPerson : 0,
-            lön: netSalary
+            lön: netSalary,
+            sparade: 0
         };
     };
 
@@ -232,21 +250,35 @@ export function renderGanttChart(
         extra: 0,
         barnbidrag: includeBenefits ? barnbidragPerPerson : 0,
         tillägg: includeBenefits ? tilläggPerPerson : 0,
-        lön: 0
+        lön: 0,
+        sparade: 0
     });
 
     const includePartner = vårdnad === 'gemensam' && beräknaPartner === 'ja';
 
+    const plan1SavingsPerMonth = plan1Savings?.perMonth || 0;
+    const plan1SavingsWeeks = plan1Savings?.weeks || 0;
+    const plan2SavingsPerMonth = plan2Savings?.perMonth || 0;
+    const plan2SavingsWeeks = plan2Savings?.weeks || 0;
+
     const period1Förälder1Inkomst = plan1.inkomst || 0;
-    const period1NoExtraFörälder1Inkomst = plan1NoExtra.inkomst || 0;
-    const period1MinFörälder1Inkomst = beräknaMånadsinkomst(180, safeDagarPerVecka(plan1.dagarPerVecka), 0, barnbidragPerPerson, tilläggPerPerson);
+    const period1NoExtraSavings = plan1NoExtra.savingsPerMonth || plan1SavingsPerMonth || 0;
+    const period1NoExtraFörälder1Inkomst = (plan1NoExtra.inkomst || 0) + period1NoExtraSavings;
+    const period1MinSavings = plan1MinDagar.savingsPerMonth || plan1SavingsPerMonth || 0;
+    const period1MinFörälder1Inkomst =
+        beräknaMånadsinkomst(180, safeDagarPerVecka(plan1MinDagar.dagarPerVecka), 0, barnbidragPerPerson, tilläggPerPerson) +
+        period1MinSavings;
     const period1OverlapFörälder1Inkomst = plan1Overlap.inkomst || 0;
     const period1Förälder2Inkomst = arbetsInkomst2 || 0;
 
     const period2Förälder1Inkomst = arbetsInkomst1 || 0;
     const period2Förälder2Inkomst = plan2.inkomst || 0;
-    const period2NoExtraFörälder2Inkomst = plan2NoExtra.inkomst || 0;
-    const period2MinFörälder2Inkomst = beräknaMånadsinkomst(180, safeDagarPerVecka(plan2.dagarPerVecka), 0, barnbidragPerPerson, tilläggPerPerson);
+    const period2NoExtraSavings = plan2NoExtra.savingsPerMonth || plan2SavingsPerMonth || 0;
+    const period2NoExtraFörälder2Inkomst = (plan2NoExtra.inkomst || 0) + period2NoExtraSavings;
+    const period2MinSavings = plan2MinDagar.savingsPerMonth || plan2SavingsPerMonth || 0;
+    const period2MinFörälder2Inkomst =
+        beräknaMånadsinkomst(180, safeDagarPerVecka(plan2MinDagar.dagarPerVecka), 0, barnbidragPerPerson, tilläggPerPerson) +
+        period2MinSavings;
 
     const period1KombExtra = period1Förälder1Inkomst + period1Förälder2Inkomst;
     const period1KombNoExtra = period1NoExtraFörälder1Inkomst + period1Förälder2Inkomst;
@@ -256,7 +288,7 @@ export function renderGanttChart(
     const period2KombMin = period2Förälder1Inkomst + period2MinFörälder2Inkomst;
 
     const dadLeaveFörälder2Inkomst = dag2 > 0 ? beräknaMånadsinkomst(dag2, 5, extra2, barnbidragPerPerson, tilläggPerPerson) : 0;
-    const dadLeaveFörälder1Inkomst = period1Förälder1Inkomst;
+    const dadLeaveFörälder1Inkomst = beräknaMånadsinkomst(dag1, 5, extra1, barnbidragPerPerson, tilläggPerPerson);
 
     let inkomstData = [];
     let draggablePoints = [];
@@ -289,13 +321,18 @@ export function renderGanttChart(
                 förälder1Inkomst = period1NoExtraFörälder1Inkomst;
                 förälder2Inkomst = vårdnad === "ensam" ? 0 : (arbetsInkomst2 || 0);
                 periodLabel = 'Förälder 1 Ledig (utan föräldralön)';
-                förälder1Components = calculateLeaveComponents(dag1, plan1.dagarPerVecka, 0);
+                förälder1Components = calculateLeaveComponents(dag1, plan1NoExtra.dagarPerVecka, 0, {
+                    savings: period1NoExtraSavings
+                });
                 förälder2Components = vårdnad === "ensam" ? createBaseComponents(false) : calculateWorkComponents(arbetsInkomst2, { includeBenefits: includePartner });
             } else if (week < period1TotalWeeks) {
                 förälder1Inkomst = period1MinFörälder1Inkomst;
                 förälder2Inkomst = vårdnad === "ensam" ? 0 : (arbetsInkomst2 || 0);
                 periodLabel = 'Förälder 1 Ledig (lägstanivå)';
-                förälder1Components = calculateLeaveComponents(180, plan1.dagarPerVecka, 0, { enforceMinimum: true });
+                förälder1Components = calculateLeaveComponents(180, plan1MinDagar.dagarPerVecka, 0, {
+                    enforceMinimum: true,
+                    savings: period1MinSavings
+                });
                 förälder2Components = vårdnad === "ensam" ? createBaseComponents(false) : calculateWorkComponents(arbetsInkomst2, { includeBenefits: includePartner });
             } else if (
                 week < period1TotalWeeks + period2ExtraWeeks &&
@@ -317,8 +354,11 @@ export function renderGanttChart(
                 förälder2Inkomst = period2NoExtraFörälder2Inkomst;
                 periodLabel = 'Förälder 2 Ledig (utan föräldralön)';
                 förälder1Components = calculateWorkComponents(arbetsInkomst1);
-                förälder2Components = calculateLeaveComponents(dag2, plan2.dagarPerVecka, 0, { includeBenefits: includePartner });
-                förälder2DaysUsed += safeDagarPerVecka(plan2.dagarPerVecka);
+                förälder2Components = calculateLeaveComponents(dag2, plan2NoExtra.dagarPerVecka, 0, {
+                    includeBenefits: includePartner,
+                    savings: period2NoExtraSavings
+                });
+                förälder2DaysUsed += safeDagarPerVecka(plan2NoExtra.dagarPerVecka);
             } else if (
                 week < period1TotalWeeks + period2TotalWeeks &&
                 vårdnad === "gemensam" &&
@@ -328,11 +368,12 @@ export function renderGanttChart(
                 förälder2Inkomst = period2MinFörälder2Inkomst;
                 periodLabel = 'Förälder 2 Ledig (lägstanivå)';
                 förälder1Components = calculateWorkComponents(arbetsInkomst1);
-                förälder2Components = calculateLeaveComponents(180, plan2.dagarPerVecka, 0, {
+                förälder2Components = calculateLeaveComponents(180, plan2MinDagar.dagarPerVecka, 0, {
                     includeBenefits: includePartner,
-                    enforceMinimum: true
+                    enforceMinimum: true,
+                    savings: period2MinSavings
                 });
-                förälder2DaysUsed += safeDagarPerVecka(plan2.dagarPerVecka);
+                förälder2DaysUsed += safeDagarPerVecka(plan2MinDagar.dagarPerVecka);
             } else {
                 förälder1Inkomst = arbetsInkomst1 || 0;
                 förälder2Inkomst = vårdnad === "ensam" ? 0 : (arbetsInkomst2 || 0);
@@ -394,7 +435,7 @@ export function renderGanttChart(
 
     if (transferredDays > 0 && genomförbarhet.status === 'ok') {
         meddelandeHtml += `
-            <span style="color: #f28c38;">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
+            <span style="color: ${transferredColor};">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
         `;
     }
     if (!genomförbarhet.ärGenomförbar && genomförbarhet.meddelande) {
@@ -406,7 +447,7 @@ export function renderGanttChart(
     meddelandeHtml += `
         <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
         Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-        <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span><br>
+        <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
         <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
         <strong>Kombinerad inkomst: ${(dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst).toLocaleString()} kr/månad</strong><br><br>
 
@@ -414,8 +455,9 @@ export function renderGanttChart(
         <span class="leave-parent parent1">Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span><br>
         <span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
         <strong>Kombinerad inkomst: ${period1KombExtra.toLocaleString()} kr/månad</strong><br>
-        ${period1NoExtraWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period1KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
-        ${period1MinWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period1KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${period1NoExtraWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1NoExtra.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period1KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
+        ${period1MinWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1MinDagar.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period1KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${plan1SavingsPerMonth > 0 && plan1SavingsWeeks > 0 ? `<span style="color: ${savingsColor};">Förälder 1 använder sparade medel: ${plan1SavingsPerMonth.toLocaleString()} kr/månad under ${(plan1SavingsWeeks / 4.3).toFixed(1)} månader (totalt ${Number(plan1Savings.total || 0).toLocaleString()} kr).</span><br><br>` : '<br>'}
 
         <strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2Start)} till ${formatDate(period2End)}</i>)</strong><br>
         <span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
@@ -423,8 +465,9 @@ export function renderGanttChart(
             ? `<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span><br>`
             : `<span class="leave-parent parent2">Förälder 2: Föräldrapenning ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span><br>`}
         <strong>Kombinerad inkomst: ${period2KombExtra.toLocaleString()} kr/månad</strong><br>
-        ${period2NoExtraWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period2KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
-        ${period2MinWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period2KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${period2NoExtraWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2NoExtra.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period2KombNoExtra.toLocaleString()} kr/månad</strong><br>` : ''}
+        ${period2MinWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2MinDagar.dagarPerVecka} dagar/vecka).</span> <strong>Kombinerad inkomst: ${period2KombMin.toLocaleString()} kr/månad</strong><br>` : ''}<br>
+        ${plan2SavingsPerMonth > 0 && plan2SavingsWeeks > 0 ? `<span style="color: ${savingsColor};">Förälder 2 använder sparade medel: ${plan2SavingsPerMonth.toLocaleString()} kr/månad under ${(plan2SavingsWeeks / 4.3).toFixed(1)} månader (totalt ${Number(plan2Savings.total || 0).toLocaleString()} kr).</span><br><br>` : '<br>'}
 
         <strong>Återstående dagar:</strong><br>
         Förälder 1: ${förälder1InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder1MinDagar.toLocaleString()} dagar (lägstanivå)<br>
@@ -516,6 +559,7 @@ export function renderGanttChart(
         period2StartDate.setDate(period2StartDate.getDate() + 1);
         const period2EndDate = new Date(period2StartDate);
         period2EndDate.setDate(period2EndDate.getDate() + (period2TotalWeeks * 7) - 1);
+        const period2Weeks = period2ExtraWeeks + period2NoExtraWeeks + period2MinWeeks;
 
         const status = statusFärger[genomförbarhet.status || 'ok'];
         let newMeddelandeHtml = `
@@ -525,7 +569,7 @@ export function renderGanttChart(
 
         if (transferredDays > 0) {
             newMeddelandeHtml += `
-                <span style="color: #f28c38;">Överförde ${transferredDays.toLocaleString()} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
+                <span style="color: ${transferredColor};">Överförde ${transferredDays.toLocaleString()} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
             `;
         }
 
@@ -533,19 +577,21 @@ export function renderGanttChart(
          newMeddelandeHtml += `
             <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
             Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-            <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-            <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad.</span><br>
+            <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
+            <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
             <strong>Kombinerad inkomst: ${(dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst).toLocaleString()} kr/månad</strong><br><br>
 
             <strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1EndDate)}</i>)</strong><br>
             <span class="leave-parent parent1">Förälder 1: ${(period1TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1TotalWeeks)} veckor), ${safeDagarPerVecka(plan1.dagarPerVecka)} dagar/vecka, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
             <span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
             <strong>Kombinerad inkomst: ${(period1Förälder1Inkomst + period1Förälder2Inkomst).toLocaleString()} kr/månad</strong><br><br>
-            
+            ${plan1SavingsPerMonth > 0 && plan1SavingsWeeks > 0 ? `<span style="color: ${savingsColor};">Sparade medel för Förälder 1: ${plan1SavingsPerMonth.toLocaleString()} kr/månad under ${(plan1SavingsWeeks / 4.3).toFixed(1)} månader.</span><br><br>` : ''}
+
             <strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2StartDate)} till ${formatDate(period2EndDate)}</i>)</strong><br>
             <span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
             <span class="leave-parent parent2">Förälder 2: ${(period2Weeks / 4.3).toFixed(1)} månader (~${Math.round(period2Weeks)} veckor), ${safeDagarPerVecka(plan2.dagarPerVecka)} dagar/vecka, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
             <strong>Kombinerad inkomst: ${(period2Förälder1Inkomst + period2Förälder2Inkomst).toLocaleString()} kr/månad</strong><br><br>
+            ${plan2SavingsPerMonth > 0 && plan2SavingsWeeks > 0 ? `<span style="color: ${savingsColor};">Sparade medel för Förälder 2: ${plan2SavingsPerMonth.toLocaleString()} kr/månad under ${(plan2SavingsWeeks / 4.3).toFixed(1)} månader.</span><br><br>` : ''}
 
 
             <strong>Återstående dagar:</strong><br>
@@ -590,6 +636,9 @@ export function renderGanttChart(
             `${data.förälder1Components.barnbidrag.toLocaleString()} kr/månad<br>`;
         html += `  Flerbarnstillägg: ` +
             `${data.förälder1Components.tillägg.toLocaleString()} kr/månad</div>`;
+        if (data.förälder1Components.sparade > 0) {
+            html += `<div class="summary-section savings">Sparade medel: ${data.förälder1Components.sparade.toLocaleString()} kr/månad</div>`;
+        }
         const showParent2 = vårdnad !== 'ensam' && beräknaPartner === 'ja';
         if (showParent2) {
             html +=
@@ -605,6 +654,9 @@ export function renderGanttChart(
                 `${data.förälder2Components.barnbidrag.toLocaleString()} kr/månad<br>`;
             html += `  Flerbarnstillägg: ` +
                 `${data.förälder2Components.tillägg.toLocaleString()} kr/månad</div>`;
+            if (data.förälder2Components.sparade > 0) {
+                html += `<div class="summary-section savings">Sparade medel: ${data.förälder2Components.sparade.toLocaleString()} kr/månad</div>`;
+            }
         }
         return html;
     }
@@ -640,42 +692,70 @@ export function renderGanttChart(
                     borderColor: ctx => {
                         const x = ctx.p0.parsed.x;
                         if (beräknaPartner === "ja" && x >= 0 && x < dadLeaveDurationWeeks) return '#800080';
+                        if (hasSavingsHighlight1 && x >= savingsHighlightStart1 && x < savingsHighlightEnd1) return savingsColor;
+                        if (hasSavingsHighlight2 && x >= savingsHighlightStart2 && x < savingsHighlightEnd2) return savingsColor;
                         if (x < period1TotalWeeks) {
-                            if (transferredWeeks > 0 && x >= transferredStartWeek) return '#f28c38';
+                            if (transferredWeeks > 0 && x >= transferredStartWeek) return transferredColor;
                             return '#28a745';
                         }
-                        if (x < period1TotalWeeks + period2TotalWeeks) return '#007bff';
+                        if (x < period1TotalWeeks + period2TotalWeeks) {
+                            if (transferredWeeks > 0 && x >= period1TotalWeeks && x < period1TotalWeeks + transferredWeeks) {
+                                return transferredColor;
+                            }
+                            return '#007bff';
+                        }
                         return 'red';
                     },
                     backgroundColor: ctx => {
                         const x = ctx.p0.parsed.x;
                         if (beräknaPartner === "ja" && x >= 0 && x < dadLeaveDurationWeeks) return '#800080';
+                        if (hasSavingsHighlight1 && x >= savingsHighlightStart1 && x < savingsHighlightEnd1) return savingsColor;
+                        if (hasSavingsHighlight2 && x >= savingsHighlightStart2 && x < savingsHighlightEnd2) return savingsColor;
                         if (x < period1TotalWeeks) {
-                            if (transferredWeeks > 0 && x >= transferredStartWeek) return '#f28c38';
+                            if (transferredWeeks > 0 && x >= transferredStartWeek) return transferredColor;
                             return '#28a745';
                         }
-                        if (x < period1TotalWeeks + period2TotalWeeks) return '#007bff';
+                        if (x < period1TotalWeeks + period2TotalWeeks) {
+                            if (transferredWeeks > 0 && x >= period1TotalWeeks && x < period1TotalWeeks + transferredWeeks) {
+                                return transferredColor;
+                            }
+                            return '#007bff';
+                        }
                         return 'red';
                     }
                 },
                 pointBackgroundColor: inkomstData.map(data => {
                     const x = data.x;
                     if (beräknaPartner === "ja" && x >= 0 && x < dadLeaveDurationWeeks) return '#800080';
+                    if (hasSavingsHighlight1 && x >= savingsHighlightStart1 && x < savingsHighlightEnd1) return savingsColor;
+                    if (hasSavingsHighlight2 && x >= savingsHighlightStart2 && x < savingsHighlightEnd2) return savingsColor;
                     if (x < period1TotalWeeks) {
-                        if (transferredWeeks > 0 && x >= transferredStartWeek) return '#f28c38';
+                        if (transferredWeeks > 0 && x >= transferredStartWeek) return transferredColor;
                         return '#28a745';
                     }
-                    if (x < period1TotalWeeks + period2TotalWeeks) return '#007bff';
+                    if (x < period1TotalWeeks + period2TotalWeeks) {
+                        if (transferredWeeks > 0 && x >= period1TotalWeeks && x < period1TotalWeeks + transferredWeeks) {
+                            return transferredColor;
+                        }
+                        return '#007bff';
+                    }
                     return 'red';
                 }),
                 pointBorderColor: inkomstData.map(data => {
                     const x = data.x;
                     if (beräknaPartner === "ja" && x >= 0 && x < dadLeaveDurationWeeks) return '#800080';
+                    if (hasSavingsHighlight1 && x >= savingsHighlightStart1 && x < savingsHighlightEnd1) return savingsColor;
+                    if (hasSavingsHighlight2 && x >= savingsHighlightStart2 && x < savingsHighlightEnd2) return savingsColor;
                     if (x < period1TotalWeeks) {
-                        if (transferredWeeks > 0 && x >= transferredStartWeek) return '#f28c38';
+                        if (transferredWeeks > 0 && x >= transferredStartWeek) return transferredColor;
                         return '#28a745';
                     }
-                    if (x < period1TotalWeeks + period2TotalWeeks) return '#007bff';
+                    if (x < period1TotalWeeks + period2TotalWeeks) {
+                        if (transferredWeeks > 0 && x >= period1TotalWeeks && x < period1TotalWeeks + transferredWeeks) {
+                            return transferredColor;
+                        }
+                        return '#007bff';
+                    }
                     return 'red';
                 })
             }]
@@ -723,7 +803,8 @@ export function renderGanttChart(
                         generateLabels: chart => [
                             { text: 'Överlappande Ledighet', fillStyle: '#800080', strokeStyle: '#800080', hidden: false },
                             { text: 'Förälder 1 Ledig', fillStyle: '#28a745', strokeStyle: '#28a745', hidden: false },
-                            transferredDays > 0 ? { text: 'Förälder 1 Ledig (Överförda dagar)', fillStyle: '#f28c38', strokeStyle: '#f28c38', hidden: false } : null,
+                            (hasSavingsHighlight1 || hasSavingsHighlight2) ? { text: 'Sparade medel', fillStyle: savingsColor, strokeStyle: savingsColor, hidden: false } : null,
+                            transferredDays > 0 ? { text: 'Förälder 1 Ledig (Överförda dagar)', fillStyle: transferredColor, strokeStyle: transferredColor, hidden: false } : null,
                             { text: 'Förälder 2 Ledig', fillStyle: '#007bff', strokeStyle: '#007bff', hidden: false },
                             { text: 'Efter Ledighet', fillStyle: 'red', strokeStyle: 'red', hidden: false }
                         ].filter(Boolean)

--- a/static/index.js
+++ b/static/index.js
@@ -44,12 +44,17 @@ function initializeForm() {
 function setupEventListeners() {
     const form = document.getElementById('calc-form');
     const optimizeBtn = document.getElementById('optimize-btn');
+    const maximizeFöräldralönBtn = document.getElementById('maximize-parental-pay-btn');
 
     // Form submission
     form.addEventListener('submit', handleFormSubmit);
 
     // Optimization button
-    optimizeBtn.addEventListener('click', handleOptimize);
+    optimizeBtn.addEventListener('click', () => runOptimization({ maximizeFöräldralön: false }));
+
+    if (maximizeFöräldralönBtn) {
+        maximizeFöräldralönBtn.addEventListener('click', () => runOptimization({ maximizeFöräldralön: true }));
+    }
 
     // Dropdown listeners for uttag
     setupDropdownListeners();
@@ -195,7 +200,7 @@ function setupDropdownListeners() {
 /**
  * Handle optimization button click
  */
-function handleOptimize() {
+function runOptimization({ maximizeFöräldralön }) {
     updateProgress(8);
     const barnDatumInput = document.getElementById('barn-datum');
     const ledigTid1Input = document.getElementById('ledig-tid-5823');
@@ -239,7 +244,8 @@ function handleOptimize() {
         ledigTid1,
         ledigTid2,
         minInkomst,
-        strategy
+        strategy,
+        maximizeFöräldralön
     };
 
     const inputs = {
@@ -294,7 +300,15 @@ function handleOptimize() {
         }
 
         // Render Gantt chart
-        document.getElementById('optimization-result').style.display = 'block';
+        const optimizationResultEl = document.getElementById('optimization-result');
+        const maximizeBtn = document.getElementById('maximize-parental-pay-btn');
+        if (optimizationResultEl) {
+            optimizationResultEl.style.display = 'block';
+        }
+        if (maximizeBtn) {
+            const hasFöräldralön = Boolean(window.appState.extra1 || window.appState.extra2);
+            maximizeBtn.style.display = hasFöräldralön ? 'inline-flex' : 'none';
+        }
         renderGanttChart(
             result.plan1,
             result.plan2,
@@ -324,7 +338,9 @@ function handleOptimize() {
             result.maxFöräldralönWeeks1,
             result.maxFöräldralönWeeks2,
             result.unusedFöräldralönWeeks1,
-            result.unusedFöräldralönWeeks2
+            result.unusedFöräldralönWeeks2,
+            result.plan1Savings,
+            result.plan2Savings
         );
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -1149,7 +1149,31 @@ canvas#gantt-canvas {
     button,
     .toggle-btn {
         width: 100%;
-    }
+}
+
+#maximize-parental-pay-btn {
+    margin-bottom: 15px;
+    background-color: #f28c38;
+    color: #fff;
+    border: none;
+    padding: 10px 18px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    transition: background-color 0.2s ease-in-out;
+}
+
+#maximize-parental-pay-btn:hover,
+#maximize-parental-pay-btn:focus {
+    background-color: #d9762c;
+    outline: none;
+}
+
+.summary-section.savings {
+    color: #f28c38;
+    font-weight: 500;
+}
 
     form,
     .result {

--- a/templates/index.html
+++ b/templates/index.html
@@ -236,6 +236,9 @@
         </div>
         <div id="optimization-result" style="display: none;">
             <h3>Optimerat schema för föräldraledighet</h3>
+            <button type="button" id="maximize-parental-pay-btn" class="secondary-action" style="display: none;">
+                Maximera föräldralön
+            </button>
             <div id="gantt-chart"></div>
         <div id="calendar-container"  style="display: none;">
 


### PR DESCRIPTION
## Summary
- add a Maximera föräldralön control to the optimization results and style it for emphasis
- extend the optimization flow to maximize parental salary usage, enforce 5-dag initial overlap, and track savings for later distribution
- update the Gantt chart rendering to reflect maximized periods, highlight redistributed savings, and show fixed 5-dag overlap incomes

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e387dbc6a8832b8896d615c8c2269f