### PR TITLE
Add parental salary maximization controls

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -83,6 +83,23 @@ button, .toggle-btn {
     border-radius: 6px;
 }
 
+.secondary-action {
+    width: auto;
+    background-color: #f28c38;
+    color: #ffffff;
+    margin-bottom: 1rem;
+    align-self: flex-start;
+}
+
+.secondary-action:hover {
+    background-color: #d97422;
+}
+
+.buffer-info {
+    color: #f28c38;
+    font-weight: 600;
+}
+
 
 
 .button-group {

--- a/templates/index.html
+++ b/templates/index.html
@@ -235,6 +235,7 @@
             <button type="button" id="optimize-btn" style="display: none;">Optimera föräldraledighet</button>
         </div>
         <div id="optimization-result" style="display: none;">
+            <button type="button" id="maximize-parental-salary-btn" class="secondary-action" style="display: none;">Maximera föräldralön</button>
             <h3>Optimerat schema för föräldraledighet</h3>
             <div id="gantt-chart"></div>
         <div id="calendar-container"  style="display: none;">


### PR DESCRIPTION
## Summary
- enforce the initial ten-day overlap at five days per week and surface maximization metadata from the leave optimizer
- add a "Maximera föräldralön" control with supporting client-side state so users can re-run the plan with full parental salary utilization
- update the Gantt rendering and styles to highlight buffered income periods and display the new action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e387dbc6a8832b8896d615c8c2269f