### PR TITLE
Turn benefit table into collapsible dropdown

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -366,11 +366,22 @@ input[type="number"] {
     padding: 1rem;
     font-weight: 500;
     cursor: pointer;
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    font-family: inherit;
+    font-size: 1rem;
 }
 
 .info-icon {
     color: #00796b;
     font-size: 1.2rem;
+}
+
+.info-header:focus-visible {
+    outline: 2px solid #2e9483;
+    outline-offset: 2px;
 }
 
 .info-arrow {
@@ -392,6 +403,14 @@ input[type="number"] {
 .info-box.open .info-content {
     display: block;
     text-align: left;
+}
+
+.benefit-table .info-content {
+    padding-top: 0;
+}
+
+.table-wrapper {
+    overflow-x: auto;
 }
 
 .combined-income {

--- a/static/ui.js
+++ b/static/ui.js
@@ -71,16 +71,39 @@ export function setupToggleButtons(groupId, inputId, callback = null) {
  * Set up toggle for info boxes
  */
 function toggleInfoBox(e) {
-    const box = e.currentTarget.closest('.info-box');
-    if (box) box.classList.toggle('open');
+    const header = e.currentTarget;
+    const box = header.closest('.info-box');
+    if (!box) return;
+    const isOpen = box.classList.toggle('open');
+    if (header instanceof HTMLElement) {
+        header.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    }
 }
 
 export function setupInfoBoxToggle() {
     const infoHeaders = document.querySelectorAll('.info-header');
     infoHeaders.forEach(header => {
         header.removeEventListener('click', toggleInfoBox);
+        if (header.tagName !== 'BUTTON') {
+            header.setAttribute('role', 'button');
+            header.setAttribute('tabindex', '0');
+            header.removeEventListener('keydown', handleInfoHeaderKeydown);
+            header.addEventListener('keydown', handleInfoHeaderKeydown);
+        } else {
+            header.removeEventListener('keydown', handleInfoHeaderKeydown);
+        }
+        const parentBox = header.closest('.info-box');
+        const isOpen = parentBox?.classList.contains('open') ?? false;
+        header.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         header.addEventListener('click', toggleInfoBox);
     });
+}
+
+function handleInfoHeaderKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        event.currentTarget.click();
+    }
 }
 
 /**
@@ -96,7 +119,6 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
     let rows = '';
     for (let i = 1; i <= 7; i++) {
         const månadsersättning = Math.round((dailyRate * i * 4.3) / 100) * 100;
-        const totalDisponibelt = månadsersättning + barnbidrag + tillägg + extra;
         const veckor = Math.floor(dagar / i);
         rows += `
             <tr>
@@ -107,16 +129,27 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
         `;
     }
     return `
-        <table>
-            <thead>
-                <tr>
-                    <th>Dagar per vecka</th>
-                    <th>Så länge räcker dagarna</th>
-                    <th>Föräldrapenning per månad</th>
-                </tr>
-            </thead>
-            <tbody>${rows}</tbody>
-        </table>
+        <div class="info-box benefit-table">
+            <button type="button" class="info-header" aria-expanded="false">
+                <span class="info-icon">📊</span>
+                <span><strong>Tabell för uttag och ersättning</strong></span>
+                <span class="info-arrow">▾</span>
+            </button>
+            <div class="info-content">
+                <div class="table-wrapper">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Dagar per vecka</th>
+                                <th>Så länge räcker dagarna</th>
+                                <th>Föräldrapenning per månad</th>
+                            </tr>
+                        </thead>
+                        <tbody>${rows}</tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
     `;
 }
 
@@ -178,11 +211,11 @@ export function generateParentSection(parentNum, dag, extra, månadsinkomst,
                     </div>
                 </div>
                 <div class="info-box">
-                    <div class="info-header">
+                    <button type="button" class="info-header" aria-expanded="false">
                         <span class="info-icon">ℹ️</span>
                         <span><strong>Information om föräldralön</strong></span>
                         <span class="info-arrow">▾</span>
-                    </div>
+                    </button>
                     <div class="info-content">
                         <p>
                             Eftersom du har kollektivavtal har du sannolikt rätt till föräldrapenningtillägg, även kallat föräldralön, från din arbetsgivare. Detta innebär ofta att du kan få upp till 90 % av din lön under en viss period av din föräldraledighet.


### PR DESCRIPTION
## Summary
- wrap the benefit breakdown table in a collapsible info-box styled dropdown with a toggle button
- enhance info box toggling to manage aria-expanded state and keyboard activation for non-button headers
- adjust styling so info-box headers render like buttons and ensure the table content scrolls responsively

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37e3ff268832b84fe677056ed741d