### PR TITLE
Add icons to parental leave preference questions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -85,12 +85,19 @@ button, .toggle-btn {
 
 
 
+.preference-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
 .button-group {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
     margin-top: 0.5rem;
-    text-align: justify
+    justify-content: center;
 }
 
 .result {

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,15 +175,17 @@
             <input type="hidden" id="strategy" value="longer">
         </div>
         
-        <div class="form-section" id="preferences-section" style="display: none;">
+            <div class="form-section" id="preferences-section" style="display: none;">
             <h3>Preferenser för föräldraledighet</h3>
             <div class="form-section">
+                <div class="question-icon"><i class="fa-solid fa-calendar-days"></i></div>
                 <label>När är barnet beräknat?</label>
                 <div class="date-picker-container">
                     <input type="date" id="barn-datum" name="barn-datum" required>
                 </div>
             </div>
             <div class="preference-group">
+                <div class="question-icon"><i class="fa-solid fa-clock"></i></div>
                 <label>Hur länge vill du vara ledig? (månader)</label>
                 <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
             </div>
@@ -200,10 +202,12 @@
                 </div>
             </div>
             <div class="preference-group" id="parent-ledig-tid" style="display: none;">
+                <div class="question-icon"><i class="fa-solid fa-user-clock"></i></div>
                 <label>Hur länge vill din partner vara ledig? (månader)</label>
                 <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
             </div>
             <div class="preference-group">
+                <div class="question-icon"><i class="fa-solid fa-coins"></i></div>
                 <label>Vad är minimigränsen för din månadsinkomst? (kr/månad)</label>
                 <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
                 <div id="min-income-error" style="color: red; display: none; margin-top: 10px;">


### PR DESCRIPTION
## Summary
- add Font Awesome question icons to the parental leave preference steps
- center the preference question layout to align the new icons with their prompts

## Testing
- Not Run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c2b995fc832b9bcab52ed74413de