### PR TITLE
Add icons to wizard progress steps

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -640,6 +640,7 @@ input[type="number"] {
     z-index: 1000;
     counter-reset: step;
     min-height: 50px;
+    --progress-circle-size: 42px;
 }
 
 #progress-bar .step {
@@ -647,20 +648,33 @@ input[type="number"] {
     text-align: center;
     flex: 1;
     color: #666; /* Unreached steps remain gray */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
 }
 
 #progress-bar .step::before {
-    content: counter(step);
-    counter-increment: step;
-    width: 30px;
-    height: 30px;
-    line-height: 30px;
+    content: none;
+}
+
+#progress-bar .step-circle {
+    width: var(--progress-circle-size);
+    height: var(--progress-circle-size);
     border: 2px solid #ccc;
-    display: block;
-    text-align: center;
-    margin: 0 auto 10px auto;
     border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background-color: white;
+    color: inherit;
+    font-size: 1.2rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+#progress-bar .step-label {
+    font-size: 0.85rem;
+    line-height: 1.1;
 }
 
 /* Completed steps (darker color) */
@@ -669,7 +683,7 @@ input[type="number"] {
     font-weight: bold;
 }
 
-#progress-bar .step.completed::before {
+#progress-bar .step.completed .step-circle {
     border-color: #1f5a58;
     background-color: #1f5a58;
     color: white;
@@ -681,7 +695,7 @@ input[type="number"] {
     font-weight: bold;
 }
 
-#progress-bar .step.active:not(.completed)::before {
+#progress-bar .step.active:not(.completed) .step-circle {
     border-color: #00796b;
     background-color: #00796b;
     color: white;
@@ -693,7 +707,7 @@ input[type="number"] {
     pointer-events: none;
 }
 
-#progress-bar .step.skipped::before {
+#progress-bar .step.skipped .step-circle {
     border-color: #757575;
     background-color: #757575;
     color: white;
@@ -703,9 +717,9 @@ input[type="number"] {
 #progress-bar .step:not(:last-child)::after {
     content: '';
     position: absolute;
-    top: 15px;
-    left: calc(50% + 15px); /* Start from the right edge of the circle */
-    width: calc(100% - 30px); /* Span to the next step, accounting for circle width */
+    top: calc(var(--progress-circle-size) / 2);
+    left: calc(50% + (var(--progress-circle-size) / 2)); /* Start from the right edge of the circle */
+    width: calc(100% - var(--progress-circle-size)); /* Span to the next step, accounting for circle width */
     height: 2px;
     background-color: #ccc;
     z-index: -1;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,15 +14,39 @@
 <body>
     <div class="container">
         <div id="progress-bar">
-            <div class="step step-1 active">Vårdnad</div>
-            <div class="step step-2">Beräkna för partner?</div>
-            <div class="step step-3">Antal barn idag</div>
-            <div class="step step-4">Antal barn planerade</div>
-            <div class="step step-5">Inkomst förälder 1</div>
-            <div class="step step-6">Inkomst förälder 2</div>
-            <div class="step step-7">Beräkna</div>
-            <div class="step step-8">Optimera</div>
-        </div>    
+            <div class="step step-1 active">
+                <div class="step-circle"><i class="fa-solid fa-people-roof"></i></div>
+                <span class="step-label">Vårdnad</span>
+            </div>
+            <div class="step step-2">
+                <div class="step-circle"><i class="fa-solid fa-user-plus"></i></div>
+                <span class="step-label">Beräkna för partner?</span>
+            </div>
+            <div class="step step-3">
+                <div class="step-circle"><i class="fa-solid fa-children"></i></div>
+                <span class="step-label">Antal barn idag</span>
+            </div>
+            <div class="step step-4">
+                <div class="step-circle"><i class="fa-solid fa-baby-carriage"></i></div>
+                <span class="step-label">Antal barn planerade</span>
+            </div>
+            <div class="step step-5">
+                <div class="step-circle"><i class="fa-solid fa-sack-dollar"></i></div>
+                <span class="step-label">Inkomst förälder 1</span>
+            </div>
+            <div class="step step-6">
+                <div class="step-circle"><i class="fa-solid fa-hand-holding-dollar"></i></div>
+                <span class="step-label">Inkomst förälder 2</span>
+            </div>
+            <div class="step step-7">
+                <div class="step-circle"><i class="fa-solid fa-calculator"></i></div>
+                <span class="step-label">Beräkna</span>
+            </div>
+            <div class="step step-8">
+                <div class="step-circle"><i class="fa-solid fa-chart-line"></i></div>
+                <span class="step-label">Optimera</span>
+            </div>
+        </div>
         
         <h1>Föräldrapenningkalkylator</h1>
         


### PR DESCRIPTION
## Summary
- add contextual Font Awesome icons to each wizard step in the progress bar
- refresh progress bar styling to display the new icon circles while preserving completion states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c8c62440832bb31524cb4542c8ed