### PR TITLE
Add icons to wizard questions and collapsible result table

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -401,6 +401,52 @@ input[type="number"] {
     text-align: left;
 }
 
+.result-box {
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    margin: 1.5rem 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+}
+
+.result-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    background-color: #f5f7f7;
+}
+
+.result-icon {
+    color: #00796b;
+    font-size: 1.2rem;
+}
+
+.result-arrow {
+    margin-left: auto;
+    transition: transform 0.3s ease;
+}
+
+.result-box.open .result-arrow {
+    transform: rotate(180deg);
+}
+
+.result-content {
+    display: none;
+    padding: 0 1rem 1rem;
+}
+
+.result-box.open .result-content {
+    display: block;
+}
+
+.result-content table {
+    margin-top: 1rem;
+}
+
 .combined-income {
     color: #2e7d32;
     font-weight: bold;
@@ -640,6 +686,7 @@ input[type="number"] {
     z-index: 1000;
     counter-reset: step;
     min-height: 50px;
+    --progress-circle-size: 42px;
 }
 
 #progress-bar .step {
@@ -647,20 +694,33 @@ input[type="number"] {
     text-align: center;
     flex: 1;
     color: #666; /* Unreached steps remain gray */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
 }
 
 #progress-bar .step::before {
-    content: counter(step);
-    counter-increment: step;
-    width: 30px;
-    height: 30px;
-    line-height: 30px;
+    content: none;
+}
+
+#progress-bar .step-circle {
+    width: var(--progress-circle-size);
+    height: var(--progress-circle-size);
     border: 2px solid #ccc;
-    display: block;
-    text-align: center;
-    margin: 0 auto 10px auto;
     border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background-color: white;
+    color: inherit;
+    font-size: 1.2rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+#progress-bar .step-label {
+    font-size: 0.85rem;
+    line-height: 1.1;
 }
 
 /* Completed steps (darker color) */
@@ -669,7 +729,7 @@ input[type="number"] {
     font-weight: bold;
 }
 
-#progress-bar .step.completed::before {
+#progress-bar .step.completed .step-circle {
     border-color: #1f5a58;
     background-color: #1f5a58;
     color: white;
@@ -681,7 +741,7 @@ input[type="number"] {
     font-weight: bold;
 }
 
-#progress-bar .step.active:not(.completed)::before {
+#progress-bar .step.active:not(.completed) .step-circle {
     border-color: #00796b;
     background-color: #00796b;
     color: white;
@@ -693,7 +753,7 @@ input[type="number"] {
     pointer-events: none;
 }
 
-#progress-bar .step.skipped::before {
+#progress-bar .step.skipped .step-circle {
     border-color: #757575;
     background-color: #757575;
     color: white;
@@ -703,9 +763,9 @@ input[type="number"] {
 #progress-bar .step:not(:last-child)::after {
     content: '';
     position: absolute;
-    top: 15px;
-    left: calc(50% + 15px); /* Start from the right edge of the circle */
-    width: calc(100% - 30px); /* Span to the next step, accounting for circle width */
+    top: calc(var(--progress-circle-size) / 2);
+    left: calc(50% + (var(--progress-circle-size) / 2)); /* Start from the right edge of the circle */
+    width: calc(100% - var(--progress-circle-size)); /* Span to the next step, accounting for circle width */
     height: 2px;
     background-color: #ccc;
     z-index: -1;

--- a/static/ui.js
+++ b/static/ui.js
@@ -71,12 +71,12 @@ export function setupToggleButtons(groupId, inputId, callback = null) {
  * Set up toggle for info boxes
  */
 function toggleInfoBox(e) {
-    const box = e.currentTarget.closest('.info-box');
+    const box = e.currentTarget.closest('.info-box, .result-box');
     if (box) box.classList.toggle('open');
 }
 
 export function setupInfoBoxToggle() {
-    const infoHeaders = document.querySelectorAll('.info-header');
+    const infoHeaders = document.querySelectorAll('.info-header, .result-header');
     infoHeaders.forEach(header => {
         header.removeEventListener('click', toggleInfoBox);
         header.addEventListener('click', toggleInfoBox);
@@ -107,16 +107,25 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
         `;
     }
     return `
-        <table>
-            <thead>
-                <tr>
-                    <th>Dagar per vecka</th>
-                    <th>Så länge räcker dagarna</th>
-                    <th>Föräldrapenning per månad</th>
-                </tr>
-            </thead>
-            <tbody>${rows}</tbody>
-        </table>
+        <div class="result-box open">
+            <div class="result-header">
+                <span class="result-icon"><i class="fa-solid fa-table-list"></i></span>
+                <span><strong>Tabell för uttag av föräldradagar</strong></span>
+                <span class="result-arrow">▾</span>
+            </div>
+            <div class="result-content">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Dagar per vecka</th>
+                            <th>Så länge räcker dagarna</th>
+                            <th>Föräldrapenning per månad</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>
+        </div>
     `;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,15 +14,39 @@
 <body>
     <div class="container">
         <div id="progress-bar">
-            <div class="step step-1 active">Vårdnad</div>
-            <div class="step step-2">Beräkna för partner?</div>
-            <div class="step step-3">Antal barn idag</div>
-            <div class="step step-4">Antal barn planerade</div>
-            <div class="step step-5">Inkomst förälder 1</div>
-            <div class="step step-6">Inkomst förälder 2</div>
-            <div class="step step-7">Beräkna</div>
-            <div class="step step-8">Optimera</div>
-        </div>    
+            <div class="step step-1 active">
+                <div class="step-circle"><i class="fa-solid fa-people-roof"></i></div>
+                <span class="step-label">Vårdnad</span>
+            </div>
+            <div class="step step-2">
+                <div class="step-circle"><i class="fa-solid fa-user-plus"></i></div>
+                <span class="step-label">Beräkna för partner?</span>
+            </div>
+            <div class="step step-3">
+                <div class="step-circle"><i class="fa-solid fa-children"></i></div>
+                <span class="step-label">Antal barn idag</span>
+            </div>
+            <div class="step step-4">
+                <div class="step-circle"><i class="fa-solid fa-baby-carriage"></i></div>
+                <span class="step-label">Antal barn planerade</span>
+            </div>
+            <div class="step step-5">
+                <div class="step-circle"><i class="fa-solid fa-sack-dollar"></i></div>
+                <span class="step-label">Inkomst förälder 1</span>
+            </div>
+            <div class="step step-6">
+                <div class="step-circle"><i class="fa-solid fa-hand-holding-dollar"></i></div>
+                <span class="step-label">Inkomst förälder 2</span>
+            </div>
+            <div class="step step-7">
+                <div class="step-circle"><i class="fa-solid fa-calculator"></i></div>
+                <span class="step-label">Beräkna</span>
+            </div>
+            <div class="step step-8">
+                <div class="step-circle"><i class="fa-solid fa-chart-line"></i></div>
+                <span class="step-label">Optimera</span>
+            </div>
+        </div>
         
         <h1>Föräldrapenningkalkylator</h1>
         
@@ -30,7 +54,7 @@
             <button type="button" id="back-btn" class="hidden back-btn">&larr; Tillbaka</button>
 
             <div class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-users"></i></div>
+                <div class="question-icon"><i class="fa-solid fa-people-roof"></i></div>
                 <label for="vårdnad">Har du Gemensam eller Ensam vårdnad?</label>
                 <div class="button-group" id="vårdnad-group">
                     <button type="button" class="vårdnad-btn toggle-btn" data-value="gemensam">Gemensam vårdnad</button>
@@ -51,7 +75,7 @@
             </div>
 
             <div class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-child"></i></div>
+                <div class="question-icon"><i class="fa-solid fa-children"></i></div>
                 <label>Hur många barn har du/ni sedan tidigare?</label>
                 <div class="button-group barnval" id="barn-tidigare-group">
                     <button type="button" class="toggle-btn" data-value="0">0</button>
@@ -83,7 +107,7 @@
             </div>
 
             <div class="form-section wizard-step" id="inkomst-avtal-1">
-                <div class="question-icon"><i class="fa-solid fa-money-bill"></i></div>
+                <div class="question-icon"><i class="fa-solid fa-sack-dollar"></i></div>
                 <label for="inkomst1">
                     Vad är din månadsinkomst före skatt?
                     <span class="help-tooltip"
@@ -124,7 +148,7 @@
             </div>
 
             <div id="inkomst-block-2" class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-money-bill"></i></div>
+                <div class="question-icon"><i class="fa-solid fa-hand-holding-dollar"></i></div>
                 <label for="inkomst2">
                     Månadsinkomst förälder 2 (före skatt):
                     <span class="help-tooltip"


### PR DESCRIPTION
## Summary
- add contextual Font Awesome icons to each wizard question so the visuals match their prompts
- make the results table collapsible with the same toggle interaction used by the info box

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c8c62440832bb31524cb4542c8ed