### PR TITLE
Highlight income shortfalls in the Gantt visualization

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -441,8 +441,26 @@ input[type="number"] {
 }
 
 .combined-income {
+    font-weight: inherit;
+}
+
+.income-flag {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-weight: 600;
     color: #2e7d32;
-    font-weight: bold;
+    background-color: transparent;
+}
+
+.income-flag.income-warning {
+    background-color: #fff4cc;
+    color: #8a6d3b;
+}
+
+.income-flag.income-error {
+    background-color: #ffd6d6;
+    color: #a94442;
 }
 .days-split {
     margin-top: 1rem;


### PR DESCRIPTION
## Summary
- compute income shortfall severity and propagate the minimum income requirement with each feasibility result
- highlight Gantt chart ranges and combined-income summaries when the plan falls short of the income threshold, including a hard error state for large gaps
- add styling and legend entries so users can distinguish near-miss versus severe income shortfalls in the chart and summary

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3ef55855c832bacbf0b7cacffea93