### PR TITLE
Ensure overlap leave uses five days and align wizard UI

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -105,7 +105,13 @@ export function optimizeParentalLeave(preferences, inputs) {
     let plan2NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan1MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan2MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
-    let plan1Overlap = { startWeek: 0, weeks: 2, dagarPerVecka: 0, inkomst: 0 };
+    let plan1Overlap = {
+        startWeek: 0,
+        weeks: 2,
+        dagarPerVecka: 0,
+        inkomst: 0,
+        inkomstUtanExtra: 0
+    };
     let plan1ExtraWeeks = 0;
     let plan1NoExtraWeeksTotal = 0;
     let plan2ExtraWeeks = 0;
@@ -432,11 +438,17 @@ export function optimizeParentalLeave(preferences, inputs) {
         };
 
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
+            const overlapDaysPerWeek = 5;
             plan1Overlap = {
                 startWeek: 0,
                 weeks: 2,
-                dagarPerVecka: dagarPerVecka1,
-                inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg))
+                dagarPerVecka: overlapDaysPerWeek,
+                inkomst: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, extra1, barnbidrag, tillägg)
+                ),
+                inkomstUtanExtra: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, 0, barnbidrag, tillägg)
+                )
             };
         }
         unusedFöräldralönWeeks1 = Math.max(0, maxFöräldralönWeeks1 - plan1ExtraWeeks);

--- a/static/chart.js
+++ b/static/chart.js
@@ -139,6 +139,7 @@ export function renderGanttChart(
     const period2NoExtraWeeks = plan2NoExtra.weeks || 0;
     const period2MinWeeks = plan2MinDagar.weeks || 0;
     const period1OverlapWeeks = plan1Overlap.weeks || 0;
+    const overlapDaysPerWeek = plan1Overlap.dagarPerVecka || 5;
 
     const baseWeeks1 = period1ExtraWeeks + period1NoExtraWeeks;
     const transferredDays = genomförbarhet.transferredDays || 0;
@@ -292,8 +293,9 @@ export function renderGanttChart(
     const period2KombNoExtra = period2Förälder1Inkomst + period2NoExtraFörälder2Inkomst;
     const period2KombMin = period2Förälder1Inkomst + period2MinFörälder2Inkomst;
 
-    const dadLeaveFörälder2Inkomst = dag2 > 0 ? beräknaMånadsinkomst(dag2, 5, extra2, barnbidragPerPerson, tilläggPerPerson) : 0;
-    const dadLeaveFörälder1Inkomst = period1Förälder1Inkomst;
+    const dadLeaveFörälder2Inkomst = dag2 > 0 ?
+        beräknaMånadsinkomst(dag2, 5, extra2, barnbidragPerPerson, tilläggPerPerson) : 0;
+    const dadLeaveFörälder1Inkomst = plan1Overlap.inkomst || period1Förälder1Inkomst;
 
     let inkomstData = [];
     let draggablePoints = [];
@@ -364,7 +366,7 @@ export function renderGanttChart(
                 förälder1Inkomst = dadLeaveFörälder1Inkomst;
                 förälder2Inkomst = dadLeaveFörälder2Inkomst;
                 periodLabel = '10-dagar vid barns födelse';
-                förälder1Components = calculateLeaveComponents(dag1, plan1.dagarPerVecka, extra1);
+                förälder1Components = calculateLeaveComponents(dag1, overlapDaysPerWeek, extra1);
                 förälder2Components = calculateLeaveComponents(dag2, 5, extra2, { includeBenefits: includePartner });
             } else if (week < period1ExtraWeeks) {
                 förälder1Inkomst = period1Förälder1Inkomst;
@@ -495,7 +497,7 @@ export function renderGanttChart(
     meddelandeHtml += `
         <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
         Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-        <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span><br>
+        <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${overlapDaysPerWeek} dagar/vecka).</span><br>
         <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
         ${formatCombinedIncome('Kombinerad inkomst:', dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst)}<br><br>
 
@@ -659,8 +661,8 @@ export function renderGanttChart(
          newMeddelandeHtml += `
             <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
             Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-            <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-            <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad.</span><br>
+            <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${overlapDaysPerWeek} dagar/vecka).</span><br>
+            <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
             ${formatCombinedIncome('Kombinerad inkomst:', dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst)}<br><br>
 
             <strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1EndDate)}</i>)</strong><br>

--- a/static/ui.js
+++ b/static/ui.js
@@ -107,13 +107,13 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
         `;
     }
     return `
-        <div class="result-box open">
-            <div class="result-header">
-                <span class="result-icon"><i class="fa-solid fa-table-list"></i></span>
+        <div class="info-box">
+            <div class="info-header">
+                <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
                 <span><strong>Tabell för uttag av föräldradagar</strong></span>
-                <span class="result-arrow">▾</span>
+                <span class="info-arrow">▾</span>
             </div>
-            <div class="result-content">
+            <div class="info-content">
                 <table>
                     <thead>
                         <tr>

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -107,14 +107,18 @@ document.addEventListener('DOMContentLoaded', () => {
             goTo(idx.barnIdag);
         } else {
             partnerSelected = true;
-            step6?.style.setProperty('display', 'block');
+            step6?.style.setProperty('display', 'flex');
             goTo(idx.partner);
         }
     });
 
     setupToggleButtons('partner-group', 'beräkna-partner', value => {
         partnerSelected = value === 'ja';
-        if (!partnerSelected) step6?.style.setProperty('display', 'none');
+        if (partnerSelected) {
+            step6?.style.setProperty('display', 'flex');
+        } else {
+            step6?.style.setProperty('display', 'none');
+        }
         goTo(idx.barnIdag);
     });
 


### PR DESCRIPTION
## Summary
- enforce a fixed five-day-per-week schedule for the initial 10-day overlap and propagate the values through the chart messaging
- convert the parental leave table box to the collapsible info-box style with an info icon by defaulting it to the closed state
- keep the "Inkomst förälder 2" wizard step aligned by showing the progress step with flex display when needed

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f3c8ebb8832b895d77de6c09ccf9