### PR TITLE
Clarify summary phases in plan overview

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -105,7 +105,13 @@ export function optimizeParentalLeave(preferences, inputs) {
     let plan2NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan1MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
     let plan2MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
-    let plan1Overlap = { startWeek: 0, weeks: 2, dagarPerVecka: 0, inkomst: 0 };
+    let plan1Overlap = {
+        startWeek: 0,
+        weeks: 2,
+        dagarPerVecka: 0,
+        inkomst: 0,
+        inkomstUtanExtra: 0
+    };
     let plan1ExtraWeeks = 0;
     let plan1NoExtraWeeksTotal = 0;
     let plan2ExtraWeeks = 0;
@@ -432,11 +438,17 @@ export function optimizeParentalLeave(preferences, inputs) {
         };
 
         if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
+            const overlapDaysPerWeek = 5;
             plan1Overlap = {
                 startWeek: 0,
                 weeks: 2,
-                dagarPerVecka: dagarPerVecka1,
-                inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg))
+                dagarPerVecka: overlapDaysPerWeek,
+                inkomst: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, extra1, barnbidrag, tillägg)
+                ),
+                inkomstUtanExtra: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, 0, barnbidrag, tillägg)
+                )
             };
         }
         unusedFöräldralönWeeks1 = Math.max(0, maxFöräldralönWeeks1 - plan1ExtraWeeks);

--- a/static/chart.js
+++ b/static/chart.js
@@ -139,6 +139,7 @@ export function renderGanttChart(
     const period2NoExtraWeeks = plan2NoExtra.weeks || 0;
     const period2MinWeeks = plan2MinDagar.weeks || 0;
     const period1OverlapWeeks = plan1Overlap.weeks || 0;
+    const overlapDaysPerWeek = plan1Overlap.dagarPerVecka || 5;
 
     const baseWeeks1 = period1ExtraWeeks + period1NoExtraWeeks;
     const transferredDays = genomförbarhet.transferredDays || 0;
@@ -154,6 +155,11 @@ export function renderGanttChart(
 
     const period1Start = new Date(startDate);
     let period1TotalWeeks = baseWeeks1 + period1MinWeeks;
+    const addDays = (date, days) => {
+        const result = new Date(date);
+        result.setDate(result.getDate() + days);
+        return result;
+    };
     const period1End = new Date(period1Start);
     period1End.setDate(period1End.getDate() + (period1TotalWeeks * 7) - 1);
 
@@ -292,8 +298,9 @@ export function renderGanttChart(
     const period2KombNoExtra = period2Förälder1Inkomst + period2NoExtraFörälder2Inkomst;
     const period2KombMin = period2Förälder1Inkomst + period2MinFörälder2Inkomst;
 
-    const dadLeaveFörälder2Inkomst = dag2 > 0 ? beräknaMånadsinkomst(dag2, 5, extra2, barnbidragPerPerson, tilläggPerPerson) : 0;
-    const dadLeaveFörälder1Inkomst = period1Förälder1Inkomst;
+    const dadLeaveFörälder2Inkomst = dag2 > 0 ?
+        beräknaMånadsinkomst(dag2, 5, extra2, barnbidragPerPerson, tilläggPerPerson) : 0;
+    const dadLeaveFörälder1Inkomst = plan1Overlap.inkomst || period1Förälder1Inkomst;
 
     let inkomstData = [];
     let draggablePoints = [];
@@ -364,7 +371,7 @@ export function renderGanttChart(
                 förälder1Inkomst = dadLeaveFörälder1Inkomst;
                 förälder2Inkomst = dadLeaveFörälder2Inkomst;
                 periodLabel = '10-dagar vid barns födelse';
-                förälder1Components = calculateLeaveComponents(dag1, plan1.dagarPerVecka, extra1);
+                förälder1Components = calculateLeaveComponents(dag1, overlapDaysPerWeek, extra1);
                 förälder2Components = calculateLeaveComponents(dag2, 5, extra2, { includeBenefits: includePartner });
             } else if (week < period1ExtraWeeks) {
                 förälder1Inkomst = period1Förälder1Inkomst;
@@ -476,52 +483,156 @@ export function renderGanttChart(
         }
     };
     const status = statusFärger[genomförbarhet.status || 'ok'];
-    let meddelandeHtml = `
-        <div class="feasibility-message" style="background-color: ${status.bakgrund}; border: 1px solid ${status.kant}; padding: 15px; margin-bottom: 15px; font-family: Inter, sans-serif;">
-            <strong style="font-size: 1.2em;">${status.titel}</strong><br><br>
-    `;
+    const parent1HasCollective = extra1 > 0 && period1ExtraWeeks > 0;
+    const parent2HasCollective = extra2 > 0 && period2ExtraWeeks > 0;
+    const showParent1Phases = parent1HasCollective || parent2HasCollective;
+    const showParent2Phases = parent2HasCollective;
 
-    if (transferredDays > 0 && genomförbarhet.status === 'ok') {
-        meddelandeHtml += `
-            <span style="color: #f28c38;">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
-        `;
-    }
-    if (!genomförbarhet.ärGenomförbar && genomförbarhet.meddelande) {
-        meddelandeHtml += `
-            <span style="color: #ff0000;">${genomförbarhet.meddelande}</span><br><br>
-        `;
-    }
+    const buildPeriodSummary = () => {
+        const period1EndDate = new Date(period1Start);
+        period1EndDate.setDate(period1EndDate.getDate() + (period1TotalWeeks * 7) - 1);
+        const period2StartDate = new Date(period1EndDate);
+        period2StartDate.setDate(period2StartDate.getDate() + 1);
+        const period2EndDate = new Date(period2StartDate);
+        period2EndDate.setDate(period2EndDate.getDate() + (period2TotalWeeks * 7) - 1);
 
-    meddelandeHtml += `
-        <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
-        Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-        <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span><br>
-        <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span><br>
-        ${formatCombinedIncome('Kombinerad inkomst:', dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst)}<br><br>
+        const parent1Fas1End = period1ExtraWeeks > 0 ? addDays(period1Start, (period1ExtraWeeks * 7) - 1) : null;
+        const parent1Fas2Start = parent1Fas1End ? addDays(parent1Fas1End, 1) : new Date(period1Start);
+        const parent2Fas1End = period2ExtraWeeks > 0 ? addDays(period2StartDate, (period2ExtraWeeks * 7) - 1) : null;
+        const parent2Fas2Start = parent2Fas1End ? addDays(parent2Fas1End, 1) : new Date(period2StartDate);
 
-        <strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1End)}</i>)</strong><br>
-        <span class="leave-parent parent1">Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span><br>
-        <span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
-        ${formatCombinedIncome('Kombinerad inkomst:', period1KombExtra)}<br>
-        ${period1NoExtraWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span> ${formatCombinedIncome('Kombinerad inkomst:', period1KombNoExtra)}<br>` : ''}
-        ${period1MinWeeks > 0 ? `<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span> ${formatCombinedIncome('Kombinerad inkomst:', period1KombMin)}<br>` : ''}<br>
+        const sections = [];
+        const overlapSection = [
+            `<strong>Period 0 (Båda föräldrarna lediga) (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong>`,
+            `Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)`,
+            `<span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad (${overlapDaysPerWeek} dagar/vecka).</span>`,
+            `<span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad (5 dagar/vecka).</span>`,
+            formatCombinedIncome('Kombinerad inkomst:', dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst)
+        ];
+        sections.push(`${overlapSection.join('<br>')}<br><br>`);
 
-        <strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2Start)} till ${formatDate(period2End)}</i>)</strong><br>
-        <span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-        ${extra2 > 0
-            ? `<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span><br>`
-            : `<span class="leave-parent parent2">Förälder 2: Föräldrapenning ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span><br>`}
-        ${formatCombinedIncome('Kombinerad inkomst:', period2KombExtra)}<br>
-        ${period2NoExtraWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span> ${formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra)}<br>` : ''}
-        ${period2MinWeeks > 0 ? `<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span> ${formatCombinedIncome('Kombinerad inkomst:', period2KombMin)}<br>` : ''}<br>
+        if (showParent1Phases) {
+            if (period1ExtraWeeks > 0) {
+                const fas1Section = [
+                    `<strong>Period 1 (Fas 1) (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(parent1Fas1End || period1EndDate)}</i>)</strong>`,
+                    `<span class="leave-parent parent1">Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`,
+                    `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`,
+                    formatCombinedIncome('Kombinerad inkomst:', period1KombExtra)
+                ];
+                sections.push(`${fas1Section.join('<br>')}<br><br>`);
+            }
 
-        <strong>Återstående dagar:</strong><br>
-        Förälder 1: ${förälder1InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder1MinDagar.toLocaleString()} dagar (lägstanivå)<br>
-        Förälder 2: ${förälder2InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder2MinDagar.toLocaleString()} dagar (lägstanivå)
-        </div>
-    `;
+            if ((period1NoExtraWeeks + period1MinWeeks) > 0) {
+                const fas2Lines = [
+                    `<strong>Period 1 (Fas 2) (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(parent1Fas2Start)} till ${formatDate(period1EndDate)}</i>)</strong>`,
+                    `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`
+                ];
+                if (period1NoExtraWeeks > 0) {
+                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period1KombNoExtra));
+                }
+                if (period1MinWeeks > 0) {
+                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period1KombMin));
+                }
+                if (fas2Lines.length === 2) {
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period1KombNoExtra));
+                }
+                sections.push(`${fas2Lines.join('<br>')}<br><br>`);
+            }
+        } else {
+            const period1Section = [
+                `<strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1EndDate)}</i>)</strong>`,
+                `<span class="leave-parent parent1">Förälder 1: ${(period1TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1TotalWeeks)} veckor), ${safeDagarPerVecka(plan1.dagarPerVecka)} dagar/vecka, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.</span>`,
+                `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`,
+                formatCombinedIncome('Kombinerad inkomst:', period1KombExtra)
+            ];
+            sections.push(`${period1Section.join('<br>')}<br><br>`);
+        }
 
-    messageDiv.innerHTML = meddelandeHtml;
+        if (showParent2Phases) {
+            if (period2ExtraWeeks > 0) {
+                const fas1Section = [
+                    `<strong>Period 2 (Fas 1) (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2StartDate)} till ${formatDate(parent2Fas1End || period2EndDate)}</i>)</strong>`,
+                    `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`,
+                    `<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`,
+                    formatCombinedIncome('Kombinerad inkomst:', period2KombExtra)
+                ];
+                sections.push(`${fas1Section.join('<br>')}<br><br>`);
+            }
+
+            if ((period2NoExtraWeeks + period2MinWeeks) > 0) {
+                const fas2Lines = [
+                    `<strong>Period 2 (Fas 2) (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(parent2Fas2Start)} till ${formatDate(period2EndDate)}</i>)</strong>`,
+                    `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`
+                ];
+                if (period2NoExtraWeeks > 0) {
+                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra));
+                }
+                if (period2MinWeeks > 0) {
+                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombMin));
+                }
+                if (fas2Lines.length === 2) {
+                    fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra));
+                }
+                sections.push(`${fas2Lines.join('<br>')}<br><br>`);
+            }
+        } else {
+            const period2Lines = [
+                `<strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2StartDate)} till ${formatDate(period2EndDate)}</i>)</strong>`,
+                `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`
+            ];
+            if (extra2 > 0 && period2ExtraWeeks > 0) {
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombExtra));
+            } else {
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2TotalWeeks)} veckor), ${safeDagarPerVecka(plan2.dagarPerVecka)} dagar/vecka, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.</span>`);
+                period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombExtra));
+            }
+            if (extra2 > 0 && period2NoExtraWeeks > 0) {
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra));
+            }
+            if (period2MinWeeks > 0) {
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombMin));
+            }
+            sections.push(`${period2Lines.join('<br>')}<br><br>`);
+        }
+
+        let remaining = `<strong>Återstående dagar:</strong><br>` +
+            `Förälder 1: ${förälder1InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder1MinDagar.toLocaleString()} dagar (lägstanivå)<br>` +
+            `Förälder 2: ${förälder2InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder2MinDagar.toLocaleString()} dagar (lägstanivå)`;
+        if (unusedFöräldralönWeeks1 > 0 && maxFöräldralönWeeks1 > 0) {
+            const allowedMonths1 = (maxFöräldralönWeeks1 / 4.3).toFixed(0);
+            remaining += `<br><span style="color: #f28c38;">Förälder 1: Du har möjlighet att ta ut föräldralön i upp till ${allowedMonths1} månader men utnyttjar just nu inte allt.</span>`;
+        }
+        if (unusedFöräldralönWeeks2 > 0 && maxFöräldralönWeeks2 > 0) {
+            const allowedMonths2 = (maxFöräldralönWeeks2 / 4.3).toFixed(0);
+            remaining += `<br><span style="color: #f28c38;">Förälder 2: Du har möjlighet att ta ut föräldralön i upp till ${allowedMonths2} månader men utnyttjar just nu inte allt.</span>`;
+        }
+        sections.push(remaining);
+
+        return sections.join('');
+    };
+
+    const buildFeasibilityHtml = () => {
+        let html = `<div class="feasibility-message" style="background-color: ${status.bakgrund}; border: 1px solid ${status.kant}; padding: 15px; margin-bottom: 15px; font-family: Inter, sans-serif;">` +
+            `<strong style="font-size: 1.2em;">${status.titel}</strong><br><br>`;
+        if (transferredDays > 0 && genomförbarhet.status === 'ok') {
+            html += `<span style="color: #f28c38;">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>`;
+        }
+        if (!genomförbarhet.ärGenomförbar && genomförbarhet.meddelande) {
+            html += `<span style="color: #ff0000;">${genomförbarhet.meddelande}</span><br><br>`;
+        }
+        html += buildPeriodSummary();
+        html += '</div>';
+        return html;
+    };
+
+    messageDiv.innerHTML = buildFeasibilityHtml();
     ganttChart.appendChild(messageDiv);
     ganttChart.appendChild(canvas);
     ganttChart.appendChild(summaryBox);
@@ -636,58 +747,7 @@ export function renderGanttChart(
     };
 
     function updateMessage() {
-        const period1EndDate = new Date(period1Start);
-        period1EndDate.setDate(period1EndDate.getDate() + (period1TotalWeeks * 7) - 1);
-        const period2StartDate = new Date(period1EndDate);
-        period2StartDate.setDate(period2StartDate.getDate() + 1);
-        const period2EndDate = new Date(period2StartDate);
-        period2EndDate.setDate(period2EndDate.getDate() + (period2TotalWeeks * 7) - 1);
-
-        const status = statusFärger[genomförbarhet.status || 'ok'];
-        let newMeddelandeHtml = `
-            <div class="feasibility-message" style="background-color: ${status.bakgrund}; border: 1px solid ${status.kant}; padding: 15px; margin-bottom: 15px; font-family: Inter, sans-serif;">
-                <strong style="font-size: 1.2em;">${status.titel}</strong><br><br>
-        `;
-
-        if (transferredDays > 0) {
-            newMeddelandeHtml += `
-                <span style="color: #f28c38;">Överförde ${transferredDays.toLocaleString()} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>
-            `;
-        }
-
-
-         newMeddelandeHtml += `
-            <strong>10 dagar efter barns födsel (<i>${formatDate(dadLeaveStart)} till ${formatDate(dadLeaveEnd)}</i>)</strong><br>
-            Överlappande ledighet: 10 arbetsdagar (${dadLeaveDurationWeeks} veckor)<br>
-            <span class="leave-parent parent1">Förälder 1: Inkomst ${dadLeaveFörälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-            <span class="leave-parent parent2">Förälder 2: Inkomst ${dadLeaveFörälder2Inkomst.toLocaleString()} kr/månad.</span><br>
-            ${formatCombinedIncome('Kombinerad inkomst:', dadLeaveFörälder1Inkomst + dadLeaveFörälder2Inkomst)}<br><br>
-
-            <strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1EndDate)}</i>)</strong><br>
-            <span class="leave-parent parent1">Förälder 1: ${(period1TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1TotalWeeks)} veckor), ${safeDagarPerVecka(plan1.dagarPerVecka)} dagar/vecka, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-            <span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
-            ${formatCombinedIncome('Kombinerad inkomst:', period1Förälder1Inkomst + period1Förälder2Inkomst)}<br><br>
-            
-            <strong>Period 2 (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2StartDate)} till ${formatDate(period2EndDate)}</i>)</strong><br>
-            <span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span><br>
-            <span class="leave-parent parent2">Förälder 2: ${(period2TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2TotalWeeks)} veckor), ${safeDagarPerVecka(plan2.dagarPerVecka)} dagar/vecka, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.</span><br>
-            ${formatCombinedIncome('Kombinerad inkomst:', period2Förälder1Inkomst + period2Förälder2Inkomst)}<br><br>
-
-
-            <strong>Återstående dagar:</strong><br>
-            Förälder 1: ${förälder1InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder1MinDagar.toLocaleString()} dagar (lägstanivå)<br>
-            Förälder 2: ${förälder2InkomstDagar.toLocaleString()} dagar (sjukpenningnivå), ${förälder2MinDagar.toLocaleString()} dagar (lägstanivå)`;
-        if (unusedFöräldralönWeeks1 > 0 && maxFöräldralönWeeks1 > 0) {
-            const allowedMonths1 = (maxFöräldralönWeeks1 / 4.3).toFixed(0);
-            newMeddelandeHtml += `<br><span style="color: #f28c38;">Förälder 1: Du har möjlighet att ta ut föräldralön i upp till ${allowedMonths1} månader men utnyttjar just nu inte allt.</span>`;
-        }
-        if (unusedFöräldralönWeeks2 > 0 && maxFöräldralönWeeks2 > 0) {
-            const allowedMonths2 = (maxFöräldralönWeeks2 / 4.3).toFixed(0);
-            newMeddelandeHtml += `<br><span style="color: #f28c38;">Förälder 2: Du har möjlighet att ta ut föräldralön i upp till ${allowedMonths2} månader men utnyttjar just nu inte allt.</span>`;
-        }
-        newMeddelandeHtml += `</div>`;
-
-        messageDiv.innerHTML = newMeddelandeHtml;
+        messageDiv.innerHTML = buildFeasibilityHtml();
     }
 
     // Reusable function to format tooltip/summary data

--- a/static/ui.js
+++ b/static/ui.js
@@ -107,13 +107,13 @@ export function genereraTabell(dailyRate, dagar, extra = 0, barnbidrag = 0, till
         `;
     }
     return `
-        <div class="result-box open">
-            <div class="result-header">
-                <span class="result-icon"><i class="fa-solid fa-table-list"></i></span>
+        <div class="info-box">
+            <div class="info-header">
+                <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
                 <span><strong>Tabell för uttag av föräldradagar</strong></span>
-                <span class="result-arrow">▾</span>
+                <span class="info-arrow">▾</span>
             </div>
-            <div class="result-content">
+            <div class="info-content">
                 <table>
                     <thead>
                         <tr>

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -107,14 +107,18 @@ document.addEventListener('DOMContentLoaded', () => {
             goTo(idx.barnIdag);
         } else {
             partnerSelected = true;
-            step6?.style.setProperty('display', 'block');
+            step6?.style.setProperty('display', 'flex');
             goTo(idx.partner);
         }
     });
 
     setupToggleButtons('partner-group', 'beräkna-partner', value => {
         partnerSelected = value === 'ja';
-        if (!partnerSelected) step6?.style.setProperty('display', 'none');
+        if (partnerSelected) {
+            step6?.style.setProperty('display', 'flex');
+        } else {
+            step6?.style.setProperty('display', 'none');
+        }
         goTo(idx.barnIdag);
     });
 


### PR DESCRIPTION
## Summary
- rename the overlap section to "Period 0" and add phase-aware headings in the summary for clearer period naming
- show phase breakdowns only when collective agreements apply and suppress duplicate partner rows when no parental salary is available
- reuse a single summary builder so live updates mirror the rendered feasibility message

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f3c8ebb8832b895d77de6c09ccf9