### PR TITLE
Add parental salary strategy option and clarify day overuse errors

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -97,7 +97,7 @@ export function beräknaBarnbidrag(totalBarn, ensamVårdnad) {
  * @param {Object} inputs - Input data (inkomst1, vårdnad, etc.)
  * @returns {Object} Optimized leave plans and related data
  */
-export function optimizeParentalLeave(preferences, inputs) {
+function optimizeParentalLeaveLegacy(preferences, inputs) {
     const { deltid, ledigTid1, ledigTid2 = 0, minInkomst, strategy } = preferences;
     let plan1 = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, inkomstUtanExtra: 0, användaInkomstDagar: 0, användaMinDagar: 0 };
     let plan1NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0 };
@@ -514,6 +514,534 @@ export function optimizeParentalLeave(preferences, inputs) {
             användaMinDagar2 += remainingOverlapDays;
             förälder2MinDagar -= remainingOverlapDays;
         }
+    }
+
+    const phase1Incomes = [];
+    if (plan1.weeks > 0) phase1Incomes.push(plan1.inkomst + arbetsInkomst2);
+    if (plan1NoExtra.weeks > 0) phase1Incomes.push(plan1NoExtra.inkomst + arbetsInkomst2);
+    if (plan1MinDagar.weeks > 0) phase1Incomes.push(plan1MinDagar.inkomst + arbetsInkomst2);
+    const phase2Incomes = [];
+    if (plan2.weeks > 0) phase2Incomes.push(plan2.inkomst + arbetsInkomst1);
+    if (plan2NoExtra.weeks > 0) phase2Incomes.push(plan2NoExtra.inkomst + arbetsInkomst1);
+    if (plan2MinDagar.weeks > 0) phase2Incomes.push(plan2MinDagar.inkomst + arbetsInkomst1);
+
+    const minPhase1 = phase1Incomes.length ? Math.min(...phase1Incomes) : null;
+    const minPhase2 = phase2Incomes.length ? Math.min(...phase2Incomes) : null;
+
+    if (minPhase1 !== null && minPhase1 < minInkomst) {
+        genomförbarhet.ärGenomförbar = false;
+        const severity = evaluateIncomeSeverity(minPhase1);
+        updateStatusFromSeverity(severity || "warning");
+        genomförbarhet.meddelande = `Kombinerad inkomst ${minPhase1.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad (med ${plan1.dagarPerVecka} dagar/vecka).`;
+    } else if (minPhase2 !== null && minPhase2 < minInkomst) {
+        genomförbarhet.ärGenomförbar = false;
+        const severity = evaluateIncomeSeverity(minPhase2);
+        updateStatusFromSeverity(severity || "warning");
+        genomförbarhet.meddelande = `Kombinerad inkomst ${minPhase2.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad (med ${plan2.dagarPerVecka} dagar/vecka).`;
+    }
+
+    return {
+        plan1,
+        plan1NoExtra,
+        plan2,
+        plan2NoExtra,
+        plan1MinDagar,
+        plan2MinDagar,
+        plan1Overlap,
+        genomförbarhet,
+        dag1,
+        extra1,
+        dag2,
+        extra2,
+        förälder1InkomstDagar,
+        förälder2InkomstDagar,
+        förälder1MinDagar,
+        förälder2MinDagar,
+        arbetsInkomst1,
+        arbetsInkomst2,
+        maxFöräldralönWeeks1,
+        maxFöräldralönWeeks2,
+        unusedFöräldralönWeeks1,
+        unusedFöräldralönWeeks2
+    };
+}
+
+export function optimizeParentalLeave(preferences, inputs) {
+    const strategy = preferences?.strategy || "longer";
+    if (strategy === "maximize_parental_salary") {
+        return optimizeParentalLeaveParentalSalary(preferences, inputs);
+    }
+    return optimizeParentalLeaveLegacy(preferences, inputs);
+}
+
+function optimizeParentalLeaveParentalSalary(preferences, inputs) {
+    const { deltid, ledigTid1, ledigTid2 = 0, minInkomst } = preferences;
+    let plan1 = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, inkomstUtanExtra: 0, användaInkomstDagar: 0, användaMinDagar: 0 };
+    let plan1NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, användaInkomstDagar: 0 };
+    let plan2 = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, inkomstUtanExtra: 0, användaInkomstDagar: 0, användaMinDagar: 0 };
+    let plan2NoExtra = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, användaInkomstDagar: 0 };
+    let plan1MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, användaMinDagar: 0 };
+    let plan2MinDagar = { startWeek: 0, weeks: 0, dagarPerVecka: 0, inkomst: 0, användaMinDagar: 0 };
+    let plan1Overlap = {
+        startWeek: 0,
+        weeks: 2,
+        dagarPerVecka: 0,
+        inkomst: 0,
+        inkomstUtanExtra: 0
+    };
+    let plan1ExtraWeeks = 0;
+    let plan1NoExtraWeeksTotal = 0;
+    let plan2ExtraWeeks = 0;
+    let plan2NoExtraWeeksTotal = 0;
+    let genomförbarhet = {
+        ärGenomförbar: true,
+        meddelande: "",
+        transferredDays: 0,
+        status: "ok",
+        minInkomst: minInkomst,
+        maxShortfallRatio: 0
+    };
+
+    const updateStatusFromSeverity = severity => {
+        if (severity === "error") {
+            genomförbarhet.status = "error";
+        } else if (severity === "warning" && genomförbarhet.status !== "error") {
+            genomförbarhet.status = "warning";
+        }
+    };
+
+    const evaluateIncomeSeverity = income => {
+        if (minInkomst <= 0 || income >= minInkomst) {
+            return null;
+        }
+        const diff = minInkomst - income;
+        const ratio = minInkomst > 0 ? diff / minInkomst : 0;
+        const severity = ratio > 0.10 ? "error" : "warning";
+        if (ratio > genomförbarhet.maxShortfallRatio) {
+            genomförbarhet.maxShortfallRatio = ratio;
+        }
+        return severity;
+    };
+
+    const barnbidrag = inputs.barnbidragPerPerson || 1250;
+    const tillägg = inputs.tilläggPerPerson || 75;
+
+    const inkomst1 = Number(inputs.inkomst1) || 0;
+    const inkomst2 = Number(inputs.inkomst2) || 0;
+
+    if (isNaN(inkomst1) || isNaN(inkomst2) || isNaN(ledigTid1) || isNaN(ledigTid2)) {
+        throw new Error("Invalid input values: incomes and leave durations must be numbers.");
+    }
+
+    const anst1 = inputs.anställningstid1 || "";
+    const anst2 = inputs.anställningstid2 || "";
+    const avtal1Ja = inputs.avtal1 === "ja" || inputs.avtal1 === true;
+    const avtal2Ja = inputs.avtal2 === "ja" || inputs.avtal2 === true;
+    const dag1 = beräknaDaglig(inkomst1);
+    const extra1 = avtal1Ja && anst1 !== "0-5" ? beräknaFöräldralön(inkomst1) : 0;
+    const dag2 = inkomst2 > 0 ? beräknaDaglig(inkomst2) : 0;
+    const extra2 = avtal2Ja && anst2 !== "0-5" ? beräknaFöräldralön(inkomst2) : 0;
+
+    const maxFöräldralönWeeks1 = avtal1Ja
+        ? anst1 === "6-12" ? 2 * 4.3 : anst1 === ">1" ? 6 * 4.3 : 0
+        : 0;
+    const maxFöräldralönWeeks2 = avtal2Ja
+        ? anst2 === "6-12" ? 2 * 4.3 : anst2 === ">1" ? 6 * 4.3 : 0
+        : 0;
+    let unusedFöräldralönWeeks1 = 0;
+    let unusedFöräldralönWeeks2 = 0;
+
+    let förälder1InkomstDagar = inputs.vårdnad === "ensam" ? 390 : 195;
+    let förälder2InkomstDagar = inputs.vårdnad === "ensam" ? 0 : 195;
+    let förälder1MinDagar = inputs.vårdnad === "ensam" ? 90 : 45;
+    let förälder2MinDagar = inputs.vårdnad === "ensam" ? 0 : 45;
+    let användaInkomstDagar1 = 0;
+    let användaInkomstDagar2 = 0;
+    let användaMinDagar1 = 0;
+    let användaMinDagar2 = 0;
+
+    const arbetsInkomst1 = beräknaNetto(inkomst1) + barnbidrag + tillägg;
+    const arbetsInkomst2 = inkomst2 > 0 ? beräknaNetto(inkomst2) + barnbidrag + tillägg : 0;
+
+    let dagarPerVecka1 = 0;
+    let dagarPerVecka1NoExtra = 0;
+    let dagarPerVecka2 = 0;
+    let weeks1 = Math.round(ledigTid1 * 4.3);
+    let weeks2 = Math.round(ledigTid2 * 4.3);
+    let inkomst1Result = arbetsInkomst1;
+    let inkomst2Result = arbetsInkomst2;
+    let kombineradInkomst = 0;
+
+    const maxDagarPerVecka = deltid === "ja" ? 5 : 7;
+    if (weeks1 > 0) {
+        dagarPerVecka1 = Math.min(maxDagarPerVecka, Math.max(1, Math.floor(förälder1InkomstDagar / weeks1)));
+    }
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && weeks2 > 0) {
+        dagarPerVecka2 = Math.min(maxDagarPerVecka, Math.max(1, Math.floor(förälder2InkomstDagar / weeks2)));
+    }
+
+    let totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+    let totalDagarBehövda2 = weeks2 * dagarPerVecka2;
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && totalDagarBehövda1 > förälder1InkomstDagar) {
+        const minDagarBehövda2 = weeks2 * dagarPerVecka2;
+        const överförbaraDagar2 = Math.max(0, förälder2InkomstDagar - 90 - minDagarBehövda2 - 10);
+        const överförDagar = Math.min(överförbaraDagar2, totalDagarBehövda1 - förälder1InkomstDagar);
+        förälder2InkomstDagar -= överförDagar;
+        förälder1InkomstDagar += överförDagar;
+        totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+        genomförbarhet.transferredDays += överförDagar;
+    }
+
+    if (totalDagarBehövda1 > förälder1InkomstDagar) {
+        dagarPerVecka1 = Math.max(1, Math.floor(förälder1InkomstDagar / weeks1));
+        totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+        if (totalDagarBehövda1 > förälder1InkomstDagar) {
+            totalDagarBehövda1 = förälder1InkomstDagar;
+            weeks1 = Math.floor(totalDagarBehövda1 / dagarPerVecka1) || 1;
+        }
+    }
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && totalDagarBehövda2 > förälder2InkomstDagar) {
+        dagarPerVecka2 = Math.max(1, Math.floor(förälder2InkomstDagar / weeks2));
+        totalDagarBehövda2 = weeks2 * dagarPerVecka2;
+        if (totalDagarBehövda2 > förälder2InkomstDagar) {
+            totalDagarBehövda2 = förälder2InkomstDagar;
+            weeks2 = Math.floor(totalDagarBehövda2 / dagarPerVecka2) || 1;
+        }
+    }
+
+    if (weeks1 > 0) {
+        inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
+        inkomst2Result = arbetsInkomst2;
+        kombineradInkomst = inkomst1Result + inkomst2Result;
+
+        if (kombineradInkomst < minInkomst && dagarPerVecka1 < 7) {
+            const möjligaDagar = Math.min(7, Math.floor(förälder1InkomstDagar / weeks1));
+            if (möjligaDagar > dagarPerVecka1) {
+                dagarPerVecka1 = möjligaDagar;
+                inkomst1Result = beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg);
+                kombineradInkomst = inkomst1Result + inkomst2Result;
+            }
+        }
+        if (kombineradInkomst < minInkomst) {
+            genomförbarhet.ärGenomförbar = false;
+            const severity = evaluateIncomeSeverity(kombineradInkomst);
+            updateStatusFromSeverity(severity || "warning");
+            genomförbarhet.meddelande =
+                `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad (med ${dagarPerVecka1} dagar/vecka).`;
+        }
+        totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+        if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && totalDagarBehövda1 > förälder1InkomstDagar) {
+            const minDagarBehövda2 = weeks2 * dagarPerVecka2;
+            const överförbaraDagar2 = Math.max(0, förälder2InkomstDagar - 90 - minDagarBehövda2 - 10);
+            const överförDagar = Math.min(överförbaraDagar2, totalDagarBehövda1 - förälder1InkomstDagar);
+            förälder2InkomstDagar -= överförDagar;
+            förälder1InkomstDagar += överförDagar;
+            genomförbarhet.transferredDays += överförDagar;
+            totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+        }
+        if (totalDagarBehövda1 > förälder1InkomstDagar) {
+            dagarPerVecka1 = Math.max(1, Math.floor(förälder1InkomstDagar / weeks1));
+            totalDagarBehövda1 = weeks1 * dagarPerVecka1;
+            if (totalDagarBehövda1 > förälder1InkomstDagar) {
+                totalDagarBehövda1 = förälder1InkomstDagar;
+                weeks1 = Math.floor(totalDagarBehövda1 / dagarPerVecka1) || 1;
+            }
+        }
+    }
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && weeks2 > 0) {
+        inkomst1Result = arbetsInkomst1;
+        inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
+        kombineradInkomst = inkomst1Result + inkomst2Result;
+
+        if (kombineradInkomst < minInkomst && dagarPerVecka2 < 7) {
+            const möjligaDagar = Math.min(7, Math.floor(förälder2InkomstDagar / weeks2));
+            if (möjligaDagar > dagarPerVecka2) {
+                dagarPerVecka2 = möjligaDagar;
+                inkomst2Result = beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg);
+                kombineradInkomst = inkomst1Result + inkomst2Result;
+            }
+        }
+        if (kombineradInkomst < minInkomst) {
+            genomförbarhet.ärGenomförbar = false;
+            const severity = evaluateIncomeSeverity(kombineradInkomst);
+            updateStatusFromSeverity(severity || "warning");
+            genomförbarhet.meddelande =
+                `Kombinerad inkomst ${kombineradInkomst.toLocaleString()} kr/månad i fas 2 är under kravet ${minInkomst.toLocaleString()} kr/månad (med ${dagarPerVecka2} dagar/vecka).`;
+        }
+        totalDagarBehövda2 = weeks2 * dagarPerVecka2;
+        if (totalDagarBehövda2 > förälder2InkomstDagar) {
+            dagarPerVecka2 = Math.max(1, Math.floor(förälder2InkomstDagar / weeks2));
+            totalDagarBehövda2 = weeks2 * dagarPerVecka2;
+            if (totalDagarBehövda2 > förälder2InkomstDagar) {
+                totalDagarBehövda2 = förälder2InkomstDagar;
+                weeks2 = Math.floor(totalDagarBehövda2 / dagarPerVecka2) || 1;
+            }
+        }
+    }
+
+    const allocateIncomeDays = ({ totalDays, extraWeeks, noExtraWeeks, maxPerWeek, enforceHighExtra }) => {
+        const safeExtraWeeks = Math.max(0, Math.round(extraWeeks));
+        const safeNoExtraWeeks = Math.max(0, Math.round(noExtraWeeks));
+
+        if (totalDays <= 0 || (safeExtraWeeks === 0 && safeNoExtraWeeks === 0)) {
+            return {
+                dagarPerVeckaExtra: 0,
+                dagarPerVeckaNoExtra: 0,
+                usedExtraDays: 0,
+                usedNoExtraDays: 0
+            };
+        }
+
+        const maxExtraDays = safeExtraWeeks * maxPerWeek;
+        const maxNoExtraDays = safeNoExtraWeeks * maxPerWeek;
+        const baselineNoExtra = safeNoExtraWeeks > 0 ? Math.min(totalDays, safeNoExtraWeeks) : 0;
+        let remaining = totalDays - baselineNoExtra;
+
+        let usedExtraDays = 0;
+        if (safeExtraWeeks > 0 && remaining > 0) {
+            const minExtraPerWeek = enforceHighExtra ? Math.min(maxPerWeek, 5) : 0;
+            const minExtraDays = safeExtraWeeks * minExtraPerWeek;
+            usedExtraDays = Math.min(maxExtraDays, remaining);
+            if (usedExtraDays < minExtraDays && totalDays >= minExtraDays + baselineNoExtra) {
+                usedExtraDays = Math.min(maxExtraDays, Math.min(remaining, minExtraDays));
+            }
+            remaining -= usedExtraDays;
+        }
+
+        let usedNoExtraDays = Math.min(Math.max(0, maxNoExtraDays - baselineNoExtra), Math.max(0, remaining));
+        remaining -= usedNoExtraDays;
+        usedNoExtraDays += baselineNoExtra;
+
+        if (remaining > 0 && safeExtraWeeks > 0 && usedExtraDays < maxExtraDays) {
+            const add = Math.min(maxExtraDays - usedExtraDays, remaining);
+            usedExtraDays += add;
+            remaining -= add;
+        }
+
+        if (remaining > 0 && safeNoExtraWeeks > 0 && usedNoExtraDays < maxNoExtraDays) {
+            const add = Math.min(maxNoExtraDays - usedNoExtraDays, remaining);
+            usedNoExtraDays += add;
+            remaining -= add;
+        }
+
+        const dagarPerVeckaExtra = safeExtraWeeks > 0 ? Number((usedExtraDays / safeExtraWeeks).toFixed(2)) : 0;
+        const dagarPerVeckaNoExtra = safeNoExtraWeeks > 0 ? Number((usedNoExtraDays / safeNoExtraWeeks).toFixed(2)) : 0;
+
+        return {
+            dagarPerVeckaExtra,
+            dagarPerVeckaNoExtra,
+            usedExtraDays: Math.round(usedExtraDays),
+            usedNoExtraDays: Math.round(usedNoExtraDays)
+        };
+    };
+
+    let minDagarWeeks1 = 0;
+    let weeks1NoExtra = 0;
+    if (dagarPerVecka1 > 0) {
+        const maxFöräldralönWeeks = maxFöräldralönWeeks1;
+        if (weeks1 > maxFöräldralönWeeks) {
+            weeks1NoExtra = Math.round(weeks1 - maxFöräldralönWeeks);
+            weeks1 = Math.round(maxFöräldralönWeeks);
+        }
+        const totalWeeks1 = weeks1 + weeks1NoExtra;
+        const initialInkomstDagar1 = förälder1InkomstDagar;
+        const allocation1 = allocateIncomeDays({
+            totalDays: initialInkomstDagar1,
+            extraWeeks: weeks1,
+            noExtraWeeks: totalWeeks1 - weeks1,
+            maxPerWeek: maxDagarPerVecka,
+            enforceHighExtra: extra1 > 0
+        });
+
+        dagarPerVecka1 = allocation1.dagarPerVeckaExtra;
+        dagarPerVecka1NoExtra = allocation1.dagarPerVeckaNoExtra;
+
+        let extraDaysUsed1 = allocation1.usedExtraDays;
+        let noExtraDaysUsed1 = allocation1.usedNoExtraDays;
+        användaInkomstDagar1 = extraDaysUsed1 + noExtraDaysUsed1;
+        förälder1InkomstDagar -= användaInkomstDagar1;
+        användaMinDagar1 = 0;
+        minDagarWeeks1 = 0;
+
+        plan1ExtraWeeks = extra1 > 0 ? weeks1 : 0;
+        plan1NoExtraWeeksTotal = plan1ExtraWeeks > 0 ? weeks1NoExtra : totalWeeks1;
+
+        plan1 = {
+            startWeek: 0,
+            weeks: plan1ExtraWeeks,
+            dagarPerVecka: dagarPerVecka1,
+            inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, extra1, barnbidrag, tillägg)),
+            inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1, 0, barnbidrag, tillägg)),
+            användaInkomstDagar: extraDaysUsed1,
+            användaMinDagar: användaMinDagar1
+        };
+
+        plan1NoExtra = {
+            startWeek: plan1ExtraWeeks,
+            weeks: plan1NoExtraWeeksTotal,
+            dagarPerVecka: dagarPerVecka1NoExtra,
+            inkomst: Math.round(beräknaMånadsinkomst(dag1, dagarPerVecka1NoExtra || dagarPerVecka1, 0, barnbidrag, tillägg))
+        };
+        plan1NoExtra.användaInkomstDagar = noExtraDaysUsed1;
+
+        if (plan1NoExtraWeeksTotal > 0) {
+            const nuInkomst = plan1NoExtra.inkomst + arbetsInkomst2;
+            if (nuInkomst < minInkomst) {
+                const mål = minInkomst - arbetsInkomst2;
+                let önskadeDagar = dagarPerVecka1NoExtra || dagarPerVecka1;
+                while (
+                    önskadeDagar < maxDagarPerVecka &&
+                    beräknaMånadsinkomst(dag1, önskadeDagar, 0, barnbidrag, tillägg) < mål
+                ) {
+                    önskadeDagar += 1;
+                }
+                const extraDagar =
+                    (önskadeDagar - (dagarPerVecka1NoExtra || dagarPerVecka1)) * plan1NoExtraWeeksTotal;
+                if (extraDagar > 0) {
+                    const minBehov2 = weeks2 * dagarPerVecka2;
+                    const överförbara = Math.max(
+                        0,
+                        förälder2InkomstDagar - 90 - minBehov2 - 10
+                    );
+                    const lånade = Math.min(överförbara, extraDagar);
+                    förälder2InkomstDagar -= lånade;
+                    genomförbarhet.transferredDays += lånade;
+                    användaInkomstDagar1 += lånade;
+                    const nyaNoExtraDagar = noExtraDaysUsed1 + lånade;
+                    dagarPerVecka1NoExtra = Number(
+                        (nyaNoExtraDagar / Math.max(1, plan1NoExtraWeeksTotal)).toFixed(2)
+                    );
+                    plan1NoExtra.dagarPerVecka = dagarPerVecka1NoExtra;
+                    plan1NoExtra.inkomst = Math.round(
+                        beräknaMånadsinkomst(
+                            dag1,
+                            dagarPerVecka1NoExtra,
+                            0,
+                            barnbidrag,
+                            tillägg
+                        )
+                    );
+                    noExtraDaysUsed1 = nyaNoExtraDagar;
+                    plan1NoExtra.användaInkomstDagar = nyaNoExtraDagar;
+                    användaInkomstDagar1 = extraDaysUsed1 + noExtraDaysUsed1;
+                }
+                const kombEfter = plan1NoExtra.inkomst + arbetsInkomst2;
+                if (kombEfter < minInkomst) {
+                    genomförbarhet.ärGenomförbar = false;
+                    const severity = evaluateIncomeSeverity(kombEfter);
+                    updateStatusFromSeverity(severity || "warning");
+                    genomförbarhet.meddelande =
+                        `Kombinerad inkomst ${kombEfter.toLocaleString()} kr/månad i fas 1 är under kravet ${minInkomst.toLocaleString()} kr/månad (med ${dagarPerVecka1} dagar/vecka).`;
+                }
+            }
+        }
+
+        plan1MinDagar = {
+            startWeek: plan1ExtraWeeks + plan1NoExtraWeeksTotal,
+            weeks: minDagarWeeks1,
+            dagarPerVecka: dagarPerVecka1NoExtra || dagarPerVecka1,
+            inkomst: Math.round(
+                beräknaMånadsinkomst(
+                    MINIMUM_RATE,
+                    dagarPerVecka1NoExtra || dagarPerVecka1,
+                    0,
+                    barnbidrag,
+                    tillägg
+                )
+            ),
+            användaMinDagar: 0
+        };
+
+        if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
+            const overlapDaysPerWeek = 5;
+            plan1Overlap = {
+                startWeek: 0,
+                weeks: 2,
+                dagarPerVecka: overlapDaysPerWeek,
+                inkomst: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, extra1, barnbidrag, tillägg)
+                ),
+                inkomstUtanExtra: Math.round(
+                    beräknaMånadsinkomst(dag1, overlapDaysPerWeek, 0, barnbidrag, tillägg)
+                )
+            };
+        }
+        unusedFöräldralönWeeks1 = Math.max(0, maxFöräldralönWeeks1 - plan1ExtraWeeks);
+    }
+
+    let minDagarWeeks2 = 0;
+    let weeks2NoExtra = 0;
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja" && weeks2 > 0) {
+        const maxFöräldralönWeeks = maxFöräldralönWeeks2;
+        if (weeks2 > maxFöräldralönWeeks) {
+            weeks2NoExtra = Math.round(weeks2 - maxFöräldralönWeeks);
+            weeks2 = Math.round(maxFöräldralönWeeks);
+        }
+        const totalWeeks2 = weeks2 + weeks2NoExtra;
+        const initialInkomstDagar2 = förälder2InkomstDagar;
+        const dagarBehövda2 = totalWeeks2 * dagarPerVecka2;
+
+        användaInkomstDagar2 = Math.min(dagarBehövda2, initialInkomstDagar2);
+        förälder2InkomstDagar -= användaInkomstDagar2;
+        användaMinDagar2 = Math.max(0, Math.min(dagarBehövda2 - initialInkomstDagar2, förälder2MinDagar));
+        förälder2MinDagar -= användaMinDagar2;
+        minDagarWeeks2 = 0;
+
+        plan2ExtraWeeks = extra2 > 0 ? weeks2 : 0;
+        plan2NoExtraWeeksTotal = plan2ExtraWeeks > 0 ? weeks2NoExtra : totalWeeks2;
+
+        plan2 = {
+            startWeek: plan1ExtraWeeks + plan1NoExtraWeeksTotal,
+            weeks: plan2ExtraWeeks,
+            dagarPerVecka: dagarPerVecka2,
+            inkomst: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, extra2, barnbidrag, tillägg)),
+            inkomstUtanExtra: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, 0, barnbidrag, tillägg)),
+            användaInkomstDagar: användaInkomstDagar2,
+            användaMinDagar: användaMinDagar2
+        };
+
+        const plan2StartNoExtra = plan2.startWeek + plan2ExtraWeeks;
+        const extraDaysUsed2 = Math.min(användaInkomstDagar2, Math.round(plan2ExtraWeeks * dagarPerVecka2));
+        const noExtraDaysUsed2 = Math.max(0, användaInkomstDagar2 - extraDaysUsed2);
+        plan2NoExtra = {
+            startWeek: plan2StartNoExtra,
+            weeks: plan2NoExtraWeeksTotal,
+            dagarPerVecka: dagarPerVecka2,
+            inkomst: Math.round(beräknaMånadsinkomst(dag2, dagarPerVecka2, 0, barnbidrag, tillägg)),
+            användaInkomstDagar: noExtraDaysUsed2
+        };
+
+        const minDagarWeeks2Dynamic = användaMinDagar2 > 0
+            ? Math.max(1, Math.round(användaMinDagar2 / Math.max(dagarPerVecka2, 1)))
+            : minDagarWeeks2;
+        plan2MinDagar = {
+            startWeek: plan2StartNoExtra + plan2NoExtraWeeksTotal,
+            weeks: minDagarWeeks2Dynamic,
+            dagarPerVecka: dagarPerVecka2,
+            inkomst: Math.round(beräknaMånadsinkomst(MINIMUM_RATE, dagarPerVecka2, 0, barnbidrag, tillägg)),
+            användaMinDagar: användaMinDagar2
+        };
+        unusedFöräldralönWeeks2 = Math.max(0, maxFöräldralönWeeks2 - plan2ExtraWeeks);
+    }
+
+    if (inputs.vårdnad === "gemensam" && inputs.beräknaPartner === "ja") {
+        const overlapDays = 10;
+        if (overlapDays <= förälder2InkomstDagar) {
+            förälder2InkomstDagar -= overlapDays;
+            användaInkomstDagar2 += overlapDays;
+        } else {
+            const remainingOverlapDays = overlapDays - förälder2InkomstDagar;
+            användaInkomstDagar2 += förälder2InkomstDagar;
+            förälder2InkomstDagar = 0;
+            användaMinDagar2 += remainingOverlapDays;
+            förälder2MinDagar -= remainingOverlapDays;
+        }
+        plan2.användaInkomstDagar = användaInkomstDagar2;
+        plan2.användaMinDagar = användaMinDagar2;
+        plan2MinDagar.användaMinDagar = användaMinDagar2;
     }
 
     const phase1Incomes = [];

--- a/static/chart.js
+++ b/static/chart.js
@@ -280,6 +280,17 @@ export function renderGanttChart(
     }
 
     const safeDagarPerVecka = (value) => value > 0 ? value : 1;
+    const formatDaysPerWeekLabel = value => {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric) || numeric <= 0) {
+            return '0';
+        }
+        if (Number.isInteger(numeric)) {
+            return `${numeric}`;
+        }
+        const fixed = numeric.toFixed(1);
+        return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed;
+    };
     const normalizeDaysPerWeek = (value, enforceMinimum = false) => {
         const numeric = Number(value);
         if (!Number.isFinite(numeric) || numeric <= 0) {
@@ -583,7 +594,7 @@ export function renderGanttChart(
             if (period1ExtraWeeks > 0) {
                 period1Blocks.push([
                     `<strong>Period 1 (Fas 1) (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(parent1Fas1End || period1EndDate)}</i>)</strong>`,
-                    `<span class="leave-parent parent1">Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`,
+                    `<span class="leave-parent parent1">Förälder 1: ${(period1ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1ExtraWeeks)} veckor) med föräldralön, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan1.dagarPerVecka)} dagar/vecka).</span>`,
                     `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`,
                     formatCombinedIncome('Kombinerad inkomst:', period1KombExtra)
                 ]);
@@ -595,11 +606,11 @@ export function renderGanttChart(
                     `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`
                 ];
                 if (period1NoExtraWeeks > 0) {
-                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period1NoExtraFörälder1Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan1NoExtra.dagarPerVecka || plan1.dagarPerVecka)} dagar/vecka).</span>`);
                     fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period1KombNoExtra));
                 }
                 if (period1MinWeeks > 0) {
-                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${plan1.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(`<span class="leave-parent parent1">Förälder 1: ${(period1MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1MinWeeks)} veckor) på lägstanivå, inkomst ${period1MinFörälder1Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan1MinDagar.dagarPerVecka || plan1.dagarPerVecka)} dagar/vecka).</span>`);
                     fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period1KombMin));
                 }
                 if (fas2Lines.length === 2) {
@@ -610,7 +621,7 @@ export function renderGanttChart(
         } else if (period1TotalWeeks > 0) {
             period1Blocks.push([
                 `<strong>Period 1 (Förälder 1 ledig, Förälder 2 jobbar) (<i>${formatDate(period1Start)} till ${formatDate(period1EndDate)}</i>)</strong>`,
-                `<span class="leave-parent parent1">Förälder 1: ${(period1TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1TotalWeeks)} veckor), ${safeDagarPerVecka(plan1.dagarPerVecka)} dagar/vecka, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.</span>`,
+                `<span class="leave-parent parent1">Förälder 1: ${(period1TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period1TotalWeeks)} veckor), ${formatDaysPerWeekLabel(plan1.dagarPerVecka)} dagar/vecka, inkomst ${period1Förälder1Inkomst.toLocaleString()} kr/månad.</span>`,
                 `<span class="working-parent parent2">Förälder 2: Inkomst ${period1Förälder2Inkomst.toLocaleString()} kr/månad.</span>`,
                 formatCombinedIncome('Kombinerad inkomst:', period1KombExtra)
             ]);
@@ -623,7 +634,7 @@ export function renderGanttChart(
                 period2Blocks.push([
                     `<strong>Period 2 (Fas 1) (Förälder 1 jobbar, Förälder 2 ledig) (<i>${formatDate(period2StartDate)} till ${formatDate(parent2Fas1End || period2EndDate)}</i>)</strong>`,
                     `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`,
-                    `<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`,
+                    `<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2.dagarPerVecka)} dagar/vecka).</span>`,
                     formatCombinedIncome('Kombinerad inkomst:', period2KombExtra)
                 ]);
             }
@@ -634,11 +645,11 @@ export function renderGanttChart(
                     `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`
                 ];
                 if (period2NoExtraWeeks > 0) {
-                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2NoExtra.dagarPerVecka || plan2.dagarPerVecka)} dagar/vecka).</span>`);
                     fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra));
                 }
                 if (period2MinWeeks > 0) {
-                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                    fas2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2MinDagar.dagarPerVecka || plan2.dagarPerVecka)} dagar/vecka).</span>`);
                     fas2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombMin));
                 }
                 if (fas2Lines.length === 2) {
@@ -652,18 +663,18 @@ export function renderGanttChart(
                 `<span class="working-parent parent1">Förälder 1: Inkomst ${period2Förälder1Inkomst.toLocaleString()} kr/månad.</span>`
             ];
             if (extra2 > 0 && period2ExtraWeeks > 0) {
-                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2ExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2ExtraWeeks)} veckor) med föräldralön, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2.dagarPerVecka)} dagar/vecka).</span>`);
                 period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombExtra));
             } else {
-                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2TotalWeeks)} veckor), ${safeDagarPerVecka(plan2.dagarPerVecka)} dagar/vecka, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.</span>`);
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2TotalWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2TotalWeeks)} veckor), ${formatDaysPerWeekLabel(plan2.dagarPerVecka)} dagar/vecka, inkomst ${period2Förälder2Inkomst.toLocaleString()} kr/månad.</span>`);
                 period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombExtra));
             }
             if (extra2 > 0 && period2NoExtraWeeks > 0) {
-                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2NoExtraWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2NoExtraWeeks)} veckor) utan föräldralön, inkomst ${period2NoExtraFörälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2NoExtra.dagarPerVecka || plan2.dagarPerVecka)} dagar/vecka).</span>`);
                 period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombNoExtra));
             }
             if (period2MinWeeks > 0) {
-                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${plan2.dagarPerVecka} dagar/vecka).</span>`);
+                period2Lines.push(`<span class="leave-parent parent2">Förälder 2: ${(period2MinWeeks / 4.3).toFixed(1)} månader (~${Math.round(period2MinWeeks)} veckor) på lägstanivå, inkomst ${period2MinFörälder2Inkomst.toLocaleString()} kr/månad (${formatDaysPerWeekLabel(plan2MinDagar.dagarPerVecka || plan2.dagarPerVecka)} dagar/vecka).</span>`);
                 period2Lines.push(formatCombinedIncome('Kombinerad inkomst:', period2KombMin));
             }
             period2Blocks.push(period2Lines);

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,6 +196,7 @@
             <label>Välj strategi:</label>
             <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
             <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
+            <button class="toggle-btn" data-value="maximize_parental_salary">Maximera föräldralönen</button>
             <input type="hidden" id="strategy" value="longer">
         </div>
         


### PR DESCRIPTION
## Summary
- restore the legacy optimizer for Längre ledighet/Maximera inkomst and route the new advanced allocation to a separate "Maximera föräldralönen" strategy
- expose the new strategy toggle in the UI
- clarify optimization errors by showing which parent and phases exceed available days

## Testing
- node --input-type=module <<'EOF'
import { optimizeParentalLeave } from './static/calculations.js';

const preferencesBase = {
  deltid: 'nej',
  ledigTid1: 13,
  ledigTid2: 2,
  minInkomst: 45000,
};

const inputs = {
  inkomst1: 27800,
  inkomst2: 65000,
  avtal1: 'ja',
  avtal2: 'ja',
  anställningstid1: '>1',
  anställningstid2: '>1',
  vårdnad: 'gemensam',
  beräknaPartner: 'ja',
  barnbidragPerPerson: 625,
  tilläggPerPerson: 0
};

for (const strategy of ['longer', 'maximize', 'maximize_parental_salary']) {
  const result = optimizeParentalLeave({ ...preferencesBase, strategy }, inputs);
  console.log(strategy, {
    plan1Weeks: result.plan1.weeks,
    plan1NoExtraWeeks: result.plan1NoExtra.weeks,
    plan2Weeks: result.plan2.weeks,
    status: result.genomförbarhet.status,
    remainingP1: result.förälder1InkomstDagar,
    remainingP2: result.förälder2InkomstDagar
  });
}
EOF

------
https://chatgpt.com/codex/tasks/task_e_68e4229bf138832b886111ad5f8e2ffd