### PR TITLE
Adjust leave slider handling for single-parent leave plans

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -243,8 +243,14 @@ function handleOptimize() {
     }
     if (minIncomeErr) minIncomeErr.style.display = 'none';
     const slider = document.getElementById('leave-slider');
-    const ledigTid1 = slider ? parseFloat(slider.value) || 0 : 0;
-    const ledigTid2 = Math.max(totalMonths - ledigTid1, 0);
+    const includePartner = window.appState.vårdnad === 'gemensam' && window.appState.beräknaPartner === 'ja';
+    let ledigTid1 = totalMonths;
+    if (includePartner && slider) {
+        const sliderValue = parseFloat(slider.value);
+        ledigTid1 = Number.isFinite(sliderValue) ? sliderValue : totalMonths;
+    }
+    ledigTid1 = Math.max(0, Math.min(ledigTid1, totalMonths));
+    const ledigTid2 = includePartner ? Math.max(totalMonths - ledigTid1, 0) : 0;
     const minInkomst = parseInt(minInkomstValue, 10);
     const strategy = strategyInput.value || 'longer';
     const deltid = defaultPreferences.deltid; // From config, could be made dynamic
@@ -462,8 +468,9 @@ function setupLeaveSlider() {
         slider.max = total;
         const step = total > 2 ? 1 : 0.5;
         slider.step = step;
-        const half = Math.round(total / 2);
-        slider.value = half;
+        const isSingleParent = window.appState?.vårdnad === 'ensam' || window.appState?.beräknaPartner !== 'ja';
+        const defaultValue = isSingleParent ? total : Math.round(total / 2);
+        slider.value = defaultValue;
         updateLeaveDisplay(slider, total);
         if (tickList) {
             tickList.innerHTML = '';
@@ -473,7 +480,6 @@ function setupLeaveSlider() {
         }
         if (startLabel) startLabel.textContent = '0';
         if (endLabel) endLabel.textContent = total;
-        const isSingleParent = window.appState?.vårdnad === 'ensam' || window.appState?.beräknaPartner !== 'ja';
         container.style.display = !isSingleParent && total > 0 ? 'block' : 'none';
     };
 


### PR DESCRIPTION
## Summary
- ensure single-parent leave requests allocate the full selected duration instead of the slider split
- default the leave slider to the total duration when only one parent is considered so hidden sliders do not skew inputs

## Testing
- node --experimental-default-type=module -e "import('./static/calculations.js').then(({ optimizeParentalLeave }) => { const prefs = { deltid: 'nej', ledigTid1: 16, ledigTid2: 0, minInkomst: 28000, strategy: 'longer' }; const inputs = { inkomst1: 58000, inkomst2: 0, avtal1: 'ja', avtal2: 'nej', anställningstid1: '>1', anställningstid2: '0-5', vårdnad: 'ensam', beräknaPartner: 'nej', barnbidragPerPerson: 625, tilläggPerPerson: 0, barnDatum: '2025-10-06' }; const result = optimizeParentalLeave(prefs, inputs); console.log(JSON.stringify({ weeksExtra: result.plan1.weeks, weeksNoExtra: result.plan1NoExtra.weeks, dagarNoExtra: result.plan1NoExtra.dagarPerVecka }, null, 2)); });"

------
https://chatgpt.com/codex/tasks/task_e_68e53ac69db0832b8ac428bb67c825e8