### PR TITLE
Center optimization strategy controls and update feasibility styling

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -748,7 +748,7 @@ export function renderGanttChart(
     };
 
     const buildFeasibilityHtml = () => {
-        let html = `<div class="feasibility-message" style="background-color: ${status.bakgrund}; border: 1px solid ${status.kant}; padding: 15px; margin-bottom: 15px; font-family: Inter, sans-serif;">` +
+        let html = `<div class="feasibility-message" style="background-color: ${status.bakgrund}; border: 1px solid ${status.kant}; padding: 15px; margin-bottom: 15px; font-family: Inter, sans-serif; border-radius: 10px;">` +
             `<strong style="font-size: 1.2em;">${status.titel}</strong><br><br>`;
         if (transferredDays > 0 && genomförbarhet.status === 'ok') {
             html += `<span style="color: #f28c38;">Överförde ${transferredDays} inkomstbaserade dagar till Förälder 1, används under ${transferredWeeks} veckor.</span><br><br>`;

--- a/static/style.css
+++ b/static/style.css
@@ -22,6 +22,10 @@ h3 {
     color: #969696;
     margin-bottom: 2rem;
 }
+
+#optimization-result > h3 {
+    text-align: center;
+}
 /* Behåll denna för barnantal */
 .button-group.barnval .toggle-btn {
     width: 50px;
@@ -947,6 +951,31 @@ canvas#gantt-canvas {
 
 .toggle-group {
     margin-bottom: 20px;
+}
+
+#strategy-group {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    text-align: center;
+}
+
+#strategy-group label {
+    margin: 0;
+    font-weight: 600;
+}
+
+#strategy-group .toggle-options {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+#strategy-group .toggle-btn {
+    width: auto;
 }
 .toggle-btn {
     padding: 10px 20px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -204,10 +204,11 @@
 
         <div id="result-block"></div>
         <div class="toggle-group" id="strategy-group" style="display: none;">
-            <label>Välj strategi:</label>
-            <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
-            <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
-            <button class="toggle-btn" data-value="maximize_parental_salary">Maximera föräldralönen</button>
+            <label for="strategy">Välj strategi:</label>
+            <div class="toggle-options">
+                <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
+                <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
+            </div>
             <input type="hidden" id="strategy" value="longer">
         </div>
         


### PR DESCRIPTION
## Summary
- center the optimization result heading and rework the strategy selector layout
- remove the "Maximera föräldralönen" option and keep the remaining buttons aligned side by side
- add rounded corners to the feasibility message banner for visual consistency

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e543f99028832bad31fd8f32b4a5a8