### PR TITLE
Align info icons and update preference labels

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -188,7 +188,7 @@ export function generateParentSection(parentNum, dag, extra, månadsinkomst,
                 </div>
                 <div class="info-box">
                     <div class="info-header">
-                        <span class="info-icon">ℹ️</span>
+                        <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
                         <span><strong>Information om föräldralön</strong></span>
                         <span class="info-arrow">▾</span>
                     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -232,8 +232,8 @@
                     <span id="slider-end">0</span>
                 </div>
                 <div class="slider-values">
-                    <span class="slider-value p1-value">Förälder 1: <span id="p1-months">0</span> månader</span>
-                    <span class="slider-value p2-value">Förälder 2: <span id="p2-months">0</span> månader</span>
+                    <span class="slider-value p1-value"><strong>Förälder 1:</strong> <span id="p1-months">0</span> månader</span>
+                    <span class="slider-value p2-value"><strong>Förälder 2:</strong> <span id="p2-months">0</span> månader</span>
                 </div>
             </div>
             <div class="preference-group" id="parent-ledig-tid" style="display: none;">
@@ -241,14 +241,14 @@
                 <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
             </div>
             <div class="preference-group">
-                <label>Vad är minimigränsen för din månadsinkomst? (kr/månad)</label>
+                <label>Vad är minimigränsen för hushållets månadsinkomst (netto)? (kr/månad)</label>
                 <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
                 <div id="min-income-error" style="color: red; display: none; margin-top: 10px;">
                     Vänligen ange minimigräns för din månadsinkomst.
                 </div>
                 <div class="info-box">
                     <div class="info-header">
-                        <span class="info-icon">ℹ️</span>
+                        <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
                         <span><strong>Typiska hushållsutgifter i Sverige</strong></span>
                         <span class="info-arrow">▾</span>
                     </div>


### PR DESCRIPTION
## Summary
- replace remaining text-based info icons with the Font Awesome circle info icon for consistency
- emphasize the slider parent labels and clarify the minimum income prompt in the preferences section

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e56f6ed070832bba976ac799147676