### PR TITLE
Improve period summary layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1313,6 +1313,51 @@ canvas#gantt-canvas {
     line-height: 1.5;
 }
 
+.period-summary {
+    padding: 0.25rem 0 0.75rem;
+}
+
+.summary-period-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    font-weight: 600;
+    color: #101828;
+}
+
+.summary-period-title {
+    font-size: 1.05rem;
+}
+
+.summary-phase-title {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #475467;
+}
+
+.summary-period-description {
+    margin-top: 0.25rem;
+    color: #667085;
+    font-style: italic;
+    font-size: 0.95rem;
+}
+
+.summary-period-range {
+    margin-top: 0.15rem;
+    font-size: 0.95rem;
+    color: #344054;
+    font-weight: 500;
+}
+
+.summary-body-line {
+    margin-top: 0.75rem;
+    color: #344054;
+}
+
+.summary-body-line:first-of-type {
+    margin-top: 0.85rem;
+}
+
 .summary-period-divider {
     border: 0;
     border-top: 2px solid #475467;


### PR DESCRIPTION
## Summary
- restructure the optimization period summary to render explicit period headings, phase subheadings, descriptions, and date ranges for clearer output
- add styling for the new period summary elements so headings, descriptions, and supporting rows are spaced and formatted consistently

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e57210aecc832b93142322e1e0b6b6