### PR TITLE
Refine parental leave strategies and summary output

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -387,7 +387,7 @@ function handleOptimize() {
 
             if (totalShortage1 > 0) {
                 const segments = [
-                    { label: 'Fas 1 med föräldralön', days: plan1ExtraDays },
+                    { label: 'Fas 1 (med föräldralön)', days: plan1ExtraDays },
                     { label: 'Fas 1 utan föräldralön', days: plan1NoExtraDays },
                     { label: 'Fas 1 lägstanivå', days: plan1MinDays },
                     { label: 'Fas 1 lägstanivå (forts.)', days: plan1MinContinuationDays }
@@ -399,7 +399,7 @@ function handleOptimize() {
                 } men har bara ${Math.round(maxDays1)} dagar tillgängliga. ${shortage} dagar saknas.`;
             } else {
                 const segments = [
-                    { label: 'Fas 2 med föräldralön', days: plan2ExtraDays },
+                    { label: 'Fas 2 (med föräldralön)', days: plan2ExtraDays },
                     { label: 'Fas 2 utan föräldralön', days: plan2NoExtraDays },
                     { label: 'Fas 2 lägstanivå', days: plan2MinDays },
                     { label: 'Fas 2 lägstanivå (forts.)', days: plan2MinContinuationDays },


### PR DESCRIPTION
## Summary
- ensure the maximize strategy fully uses available weekly leave and let the "Längre ledighet" mode trim unnecessary days while meeting income targets
- render the period summaries more compactly with shared lines and move the parental salary marker into the phase heading for clarity
- update shortage messaging to reference the new phase naming

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e57a92e040832b884111ea172ae9c4