### PR TITLE
Add optimization suggestions and legend update

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -417,6 +417,15 @@ function handleOptimize() {
 
         // Render Gantt chart
         document.getElementById('optimization-result').style.display = 'block';
+        const stepFromSlider = slider ? parseFloat(slider.step) : NaN;
+        const chartContext = {
+            preferences: { ...preferences },
+            inputs: { ...inputs },
+            totalMonths,
+            step: Number.isFinite(stepFromSlider) && stepFromSlider > 0
+                ? stepFromSlider
+                : (totalMonths > 2 ? 1 : 0.5)
+        };
         renderGanttChart(
             result.plan1,
             result.plan2,
@@ -450,7 +459,8 @@ function handleOptimize() {
             result.användaInkomstDagar1,
             result.användaMinDagar1,
             result.användaInkomstDagar2,
-            result.användaMinDagar2
+            result.användaMinDagar2,
+            chartContext
         );
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -1414,6 +1414,100 @@ canvas#gantt-canvas {
     color: #007bff;
 }
 
+.optimization-assist-btn {
+    width: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    margin: 0 auto 1.5rem;
+    font-size: 1rem;
+}
+
+.optimization-assist-btn.loading {
+    opacity: 0.7;
+    cursor: wait;
+}
+
+.optimization-suggestions {
+    display: none;
+    width: 100%;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+}
+
+.strategy-box {
+    flex: 1 1 320px;
+    background: #ffffff;
+    border: 1px solid #d0d5dd;
+    border-radius: 12px;
+    padding: 1.25rem;
+    box-shadow: 0 6px 18px rgba(16, 24, 40, 0.08);
+    text-align: left;
+}
+
+.strategy-box h4 {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+    color: #101828;
+}
+
+.strategy-description {
+    margin: 0 0 1rem;
+    color: #475467;
+    font-size: 0.95rem;
+}
+
+.strategy-metrics {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.strategy-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.metric-label {
+    font-weight: 600;
+    color: #101828;
+}
+
+.metric-value {
+    font-size: 0.95rem;
+    color: #344054;
+}
+
+.metric-value .metric-diff {
+    margin-left: 0.5rem;
+    font-weight: 600;
+}
+
+.metric-diff.positive {
+    color: #1b5e20;
+}
+
+.metric-diff.negative {
+    color: #c62828;
+}
+
+.metric-diff.neutral {
+    color: #475467;
+}
+
+.strategy-message {
+    text-align: center;
+    font-size: 0.95rem;
+    color: #475467;
+}
+
 
 @media (max-width: 600px) {
     .button-group {
@@ -1431,3 +1525,13 @@ canvas#gantt-canvas {
         padding: 1rem;
     }
 
+    .optimization-suggestions {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .strategy-box {
+        flex: 1 1 100%;
+    }
+
+}


### PR DESCRIPTION
## Summary
- add an optimization assistant button that surfaces alternative leave strategies with key metrics and deltas
- move the minimum household income annotation into the chart legend and reposition the legend at the bottom center
- style the new controls and pass optimization context data from the UI for suggestion generation

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e60a057cc0832b942422e20229e1c9