### PR TITLE
Enhance optimization suggestions presentation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1416,9 +1416,8 @@ canvas#gantt-canvas {
 
 .optimization-assist-btn {
     width: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    display: block;
+    text-align: center;
     padding: 0.75rem 1.5rem;
     margin: 0 auto 1.5rem;
     font-size: 1rem;
@@ -1432,10 +1431,14 @@ canvas#gantt-canvas {
 .optimization-suggestions {
     display: none;
     width: 100%;
-    gap: 1.5rem;
-    flex-wrap: wrap;
-    justify-content: center;
     margin-bottom: 1.5rem;
+}
+
+.strategy-box-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
 }
 
 .strategy-box {
@@ -1508,6 +1511,74 @@ canvas#gantt-canvas {
     color: #475467;
 }
 
+.strategy-days-block {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #e4e7ec;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.strategy-days-heading {
+    font-weight: 600;
+    color: #101828;
+    font-size: 0.95rem;
+}
+
+.strategy-days-line {
+    color: #344054;
+    font-size: 0.95rem;
+}
+
+.strategy-use-btn {
+    margin-top: 1rem;
+    width: 100%;
+    padding: 0.65rem 1rem;
+    background-color: #00796b;
+    color: #ffffff;
+    font-weight: 600;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.strategy-use-btn:hover {
+    background-color: #005f56;
+}
+
+.strategy-summary-divider {
+    border: 0;
+    border-top: 1px solid #d0d5dd;
+    margin: 1.75rem 0 1rem;
+    width: 100%;
+}
+
+.strategy-income-summary {
+    text-align: center;
+    font-size: 1rem;
+    color: #101828;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.summary-line-part {
+    margin-top: 0.35rem;
+    color: #344054;
+    font-size: 0.95rem;
+}
+
+.summary-line-part:first-child {
+    margin-top: 0.5rem;
+}
+
+.summary-line-part.combined-income-line {
+    font-weight: 600;
+    color: #101828;
+}
+
 
 @media (max-width: 600px) {
     .button-group {
@@ -1525,13 +1596,14 @@ canvas#gantt-canvas {
         padding: 1rem;
     }
 
-    .optimization-suggestions {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
     .strategy-box {
         flex: 1 1 100%;
+    }
+
+    .strategy-box-wrapper {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
     }
 
 }


### PR DESCRIPTION
## Summary
- calculate total household income for baseline and suggested strategies and surface the difference
- present optimization suggestions in Swedish with clearer day breakdowns and a one-click "Use" action
- adjust feasibility summaries and styling, including line-by-line layouts and a centered assist button

## Testing
- Manual verification of the optimization flow via browser automation

------
https://chatgpt.com/codex/tasks/task_e_68e613997f08832b9b56e71831b3a89b