### PR TITLE
Improve mobile layout and clarify remaining-day summary

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -1447,7 +1447,16 @@ export function renderGanttChart(
             const incomeDays = Math.round(toNonNegative(currentData.income));
             const minDays = Math.round(toNonNegative(currentData.min));
             const totalDays = incomeDays + minDays;
-            line.textContent = `${label}: ${totalDays.toLocaleString('sv-SE')} dagar`;
+
+            const totalSpan = document.createElement('span');
+            totalSpan.className = 'days-total';
+            totalSpan.textContent = `${label}: ${totalDays.toLocaleString('sv-SE')} dagar`;
+            line.appendChild(totalSpan);
+
+            const breakdownSpan = document.createElement('span');
+            breakdownSpan.className = 'days-breakdown';
+            breakdownSpan.textContent = ` (${incomeDays.toLocaleString('sv-SE')}/${minDays.toLocaleString('sv-SE')} dagar)`;
+            line.appendChild(breakdownSpan);
 
             if (!options.forceNeutral && baselineData) {
                 const baselineIncome = Math.round(toNonNegative(baselineData.income));
@@ -1463,7 +1472,11 @@ export function renderGanttChart(
                 if (incomeDiff && minDiff) {
                     const wrapper = document.createElement('span');
                     wrapper.className = 'days-diff-wrapper';
-                    wrapper.appendChild(document.createTextNode(' ('));
+                    wrapper.appendChild(document.createTextNode(' '));
+                    const deltaLabel = document.createElement('span');
+                    deltaLabel.className = 'days-delta-label';
+                    deltaLabel.textContent = 'Δ ';
+                    wrapper.appendChild(deltaLabel);
                     const incomeSpan = document.createElement('span');
                     incomeSpan.className = `days-diff ${incomeDiff.className}`;
                     incomeSpan.textContent = incomeDiff.text;
@@ -1473,7 +1486,7 @@ export function renderGanttChart(
                     minSpan.className = `days-diff ${minDiff.className}`;
                     minSpan.textContent = minDiff.text;
                     wrapper.appendChild(minSpan);
-                    wrapper.appendChild(document.createTextNode(' dagar)'));
+                    wrapper.appendChild(document.createTextNode(' dagar'));
                     line.appendChild(wrapper);
                 }
             }

--- a/static/style.css
+++ b/static/style.css
@@ -1,9 +1,13 @@
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 body {
     font-family: 'Inter', sans-serif;
     background: #f2f2f2;
-    padding: 2rem;
     margin: 0; /* ingen auto */
-    
+    min-height: 100vh;
+    padding: 2rem;
 }
 .toggle-btn {
     display: flex;
@@ -711,6 +715,103 @@ input[type="number"] {
     font-size: 1.3em;
 }
 
+@media (max-width: 1024px) {
+    body {
+        padding: 1.5rem;
+    }
+
+    .container {
+        max-width: 100%;
+        padding: 2rem 1.5rem;
+    }
+
+    .wizard-first-step-layout {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dev-shortcuts {
+        max-width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    .dev-family-btn {
+        flex: 1 1 calc(50% - 0.75rem);
+        min-width: 200px;
+    }
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 1rem;
+    }
+
+    h1 {
+        font-size: 1.75rem;
+        margin-bottom: 1.5rem;
+    }
+
+    form,
+    .result,
+    .result-block,
+    .result-section {
+        padding: 1.5rem 1rem;
+    }
+
+    .form-section {
+        align-items: stretch;
+        text-align: left;
+    }
+
+    .form-section .question-icon {
+        margin-bottom: 0.75rem;
+    }
+
+    .button-group {
+        justify-content: center;
+    }
+
+    .button-group .toggle-btn {
+        flex: 1 1 calc(50% - 10px);
+        min-width: 150px;
+    }
+
+    .button-group.barnval .toggle-btn {
+        flex: 1 1 calc(33% - 10px);
+        min-width: 60px;
+    }
+
+    .dev-shortcuts {
+        overflow-x: auto;
+    }
+
+    .dev-family-btn {
+        min-width: 160px;
+    }
+
+    .container {
+        margin: 90px auto 0;
+        padding: 1.5rem 1rem;
+    }
+
+    #progress-bar {
+        overflow-x: auto;
+        gap: 12px;
+        padding: 10px 12px;
+        --progress-circle-size: 36px;
+    }
+
+    #progress-bar .step {
+        min-width: 120px;
+    }
+
+    #progress-bar .step-label {
+        font-size: 0.75rem;
+    }
+}
+
 /* Responsive Adjustments */
 @media (max-width: 600px) {
     .total-total-box {
@@ -736,6 +837,53 @@ input[type="number"] {
 
     .monthly-total .total-value {
         font-size: 1.2em;
+    }
+
+    .button-group .toggle-btn {
+        min-width: 130px;
+    }
+
+    .container {
+        padding: 1.5rem 0.75rem;
+    }
+
+    #progress-bar .step {
+        min-width: 110px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 0.75rem;
+    }
+
+    form,
+    .result,
+    .result-block,
+    .result-section {
+        padding: 1.25rem 0.9rem;
+    }
+
+    .button-group .toggle-btn {
+        flex: 1 1 100%;
+        min-width: 0;
+    }
+
+    .button-group.barnval .toggle-btn {
+        flex: 1 1 30%;
+        max-width: 70px;
+    }
+
+    #progress-bar {
+        --progress-circle-size: 32px;
+    }
+
+    #progress-bar .step {
+        min-width: 95px;
+    }
+
+    #progress-bar .step-label {
+        font-size: 0.7rem;
     }
 }
 #progress-bar {
@@ -1578,8 +1726,23 @@ canvas#gantt-canvas {
     font-size: 0.95rem;
 }
 
+.days-total {
+    font-weight: 600;
+}
+
+.days-breakdown {
+    color: #475467;
+    font-weight: 500;
+}
+
 .days-diff-wrapper {
     margin-left: 0.3rem;
+}
+
+.days-delta-label {
+    color: #475467;
+    font-weight: 500;
+    margin-right: 0.1rem;
 }
 
 .days-diff {


### PR DESCRIPTION
## Summary
- show the remaining parental leave days with an explicit income/lägstanivå breakdown while keeping delta indicators
- add utility styles and responsive breakpoints so the wizard and results layout adapts cleanly on mobile screens

## Testing
- flask run --host=0.0.0.0 --port=5000


------
https://chatgpt.com/codex/tasks/task_e_68e6495b51f4832ba33c0d1d18e5ba7c