### PR TITLE
Improve mobile interactions and layout

### DIFF
--- a/static/chart.js
+++ b/static/chart.js
@@ -314,6 +314,10 @@ export function renderGanttChart(
     summaryBox.style.paddingBottom = '40px';
     summaryBox.innerHTML = '<p>Hovra över en punkt för att se detaljer.</p>';
 
+    const isMobileView = typeof window !== 'undefined'
+        ? window.matchMedia('(max-width: 720px)').matches
+        : false;
+
     const minIncomeRequirement = Number(genomförbarhet?.minInkomst) || 0;
     const highlightColors = {
         warning: 'rgba(255, 223, 94, 0.25)',
@@ -363,7 +367,7 @@ export function renderGanttChart(
                 });
             }
             entries.push({
-                text: 'Minimum household income',
+                text: 'Lägsta hushållsinkomst',
                 fillStyle: 'rgba(220, 0, 0, 0.8)',
                 strokeStyle: 'rgba(220, 0, 0, 0.8)',
                 lineWidth: 2,
@@ -617,7 +621,9 @@ export function renderGanttChart(
     const dadLeaveFörälder1Inkomst = plan1Overlap.inkomst || period1Förälder1Inkomst;
 
     const totalMonthsSelected = toFiniteNumber(optimizationContext?.totalMonths);
-    const shouldAggregatePoints = Number.isFinite(totalMonthsSelected) && totalMonthsSelected > 15;
+    const shouldAggregatePoints = isMobileView || (
+        Number.isFinite(totalMonthsSelected) && totalMonthsSelected > 15
+    );
 
     let inkomstData = [];
     let draggablePoints = [];
@@ -851,35 +857,54 @@ export function renderGanttChart(
         }
 
         const aggregated = [];
-        const processGroup = (group) => {
-            for (let i = 0; i < group.length; i += 2) {
-                const chunk = group.slice(i, i + 2);
-                if (!chunk.length) {
-                    continue;
-                }
-                const start = chunk[0];
-                const end = chunk[chunk.length - 1];
-                const representative = start.data;
-                const midpoint = (representative.x + end.data.x) / 2;
-                const sourceIndices = chunk.map(entry => entry.index);
-                const averageValue = (key) => chunk.reduce(
-                    (sum, entry) => sum + toFiniteNumber(entry.data[key]),
-                    0
-                ) / chunk.length;
+        const appendAggregatedChunk = (chunk) => {
+            if (!chunk.length) {
+                return;
+            }
+            const start = chunk[0];
+            const end = chunk[chunk.length - 1];
+            const representative = start.data;
+            const midpoint = (representative.x + end.data.x) / 2;
+            const sourceIndices = chunk.map(entry => entry.index);
+            const averageValue = (key) => chunk.reduce(
+                (sum, entry) => sum + toFiniteNumber(entry.data[key]),
+                0
+            ) / chunk.length;
 
-                aggregated.push({
-                    x: midpoint,
-                    y: averageValue('y'),
-                    förälder1Inkomst: averageValue('förälder1Inkomst'),
-                    förälder2Inkomst: averageValue('förälder2Inkomst'),
-                    periodLabel: representative.periodLabel,
-                    förälder1Components: cloneComponents(representative.förälder1Components),
-                    förälder2Components: cloneComponents(representative.förälder2Components),
-                    displayLabel: formatRangeLabel(start.data.x, end.data.x),
-                    startWeekIndex: start.data.x,
-                    endWeekIndex: end.data.x,
-                    sourceIndices
-                });
+            aggregated.push({
+                x: midpoint,
+                y: averageValue('y'),
+                förälder1Inkomst: averageValue('förälder1Inkomst'),
+                förälder2Inkomst: averageValue('förälder2Inkomst'),
+                periodLabel: representative.periodLabel,
+                förälder1Components: cloneComponents(representative.förälder1Components),
+                förälder2Components: cloneComponents(representative.förälder2Components),
+                displayLabel: formatRangeLabel(start.data.x, end.data.x),
+                startWeekIndex: start.data.x,
+                endWeekIndex: end.data.x,
+                sourceIndices
+            });
+        };
+
+        const processGroup = (group) => {
+            if (isMobileView) {
+                if (group.length <= 1) {
+                    appendAggregatedChunk(group);
+                    return;
+                }
+                if (group.length === 2) {
+                    appendAggregatedChunk(group.slice(0, 1));
+                    appendAggregatedChunk(group.slice(1));
+                    return;
+                }
+                const splitIndex = Math.ceil(group.length / 2);
+                appendAggregatedChunk(group.slice(0, splitIndex));
+                appendAggregatedChunk(group.slice(splitIndex));
+                return;
+            }
+
+            for (let i = 0; i < group.length; i += 2) {
+                appendAggregatedChunk(group.slice(i, i + 2));
             }
         };
 
@@ -1567,6 +1592,91 @@ export function renderGanttChart(
             displaySummary = baselineSummary;
         }
 
+        let summaryMessageHtml = '';
+        if (baselineIncomeTotal != null) {
+            const strategyIncomeTotal = useBaselineForDisplay
+                ? baselineIncomeTotal
+                : Math.round(toFiniteNumber(summary.totalIncome));
+            if (Number.isFinite(strategyIncomeTotal)) {
+                let dayDiffSegment = '';
+                if (baselineSummary) {
+                    const baselineRemainingTotal = Math.round(toFiniteNumber(baselineSummary.totalRemainingDays));
+                    const strategyRemainingTotal = useBaselineForDisplay
+                        ? baselineRemainingTotal
+                        : Math.round(toFiniteNumber(summary.totalRemainingDays));
+                    if (
+                        Number.isFinite(baselineRemainingTotal) &&
+                        Number.isFinite(strategyRemainingTotal)
+                    ) {
+                        const diffDays = useBaselineForDisplay
+                            ? 0
+                            : strategyRemainingTotal - baselineRemainingTotal;
+                        let diffClass = 'neutral';
+                        let diffLabel = '0 dagar';
+                        if (diffDays > 0) {
+                            diffClass = 'positive';
+                            diffLabel = `+${Math.abs(diffDays).toLocaleString('sv-SE')} dagar`;
+                        } else if (diffDays < 0) {
+                            diffClass = 'negative';
+                            diffLabel = `−${Math.abs(diffDays).toLocaleString('sv-SE')} dagar`;
+                        }
+                        dayDiffSegment = ` Antalet dagar förändras med <span class="days-diff ${diffClass}">${diffLabel}</span>.`;
+                    }
+                }
+
+                const formattedIncomeTotal = strategyIncomeTotal.toLocaleString('sv-SE');
+                let messageHtml = '';
+
+                if (useBaselineForDisplay) {
+                    if (boxData.type === 'remainingDays') {
+                        const parent1Remaining = Math.round(
+                            toNonNegative(displaySummary?.remainingDays?.parent1?.income)
+                        );
+                        const parent2Remaining = Math.round(
+                            toNonNegative(displaySummary?.remainingDays?.parent2?.income)
+                        );
+                        const totalSavedDays = parent1Remaining + parent2Remaining;
+                        const savedLabel = `${totalSavedDays.toLocaleString('sv-SE')} dagar`;
+                        messageHtml = `Denna strategi ger <span class="income-diff positive">den totala nettoinkomsten ${formattedIncomeTotal} sek</span>.<br>Med detta upplägg <span class="days-diff positive">sparar du ${savedLabel}</span>.`;
+                    } else {
+                        messageHtml = `Denna strategi ger <span class="income-diff positive">den totala nettoinkomsten ${formattedIncomeTotal} sek</span>.`;
+                    }
+                    dayDiffSegment = '';
+                } else if (strategyIncomeTotal === baselineIncomeTotal) {
+                    messageHtml = `Denna strategi ger samma totala inkomst (${formattedIncomeTotal} sek) som ditt nuvarande val.`;
+                } else {
+                    const diffValue = strategyIncomeTotal - baselineIncomeTotal;
+                    const signClass = diffValue > 0 ? 'positive' : 'negative';
+                    const signLabel = diffValue > 0 ? '+' : '−';
+                    const diffText = `${signLabel}${Math.abs(diffValue).toLocaleString('sv-SE')} sek`;
+                    messageHtml = `Totala hushållsinkomsten blir <strong>${formattedIncomeTotal} sek</strong> med den här strategin, vilket är <span class="income-diff ${signClass}">${diffText}</span> jämfört med ditt nuvarande val.`;
+                }
+
+                summaryMessageHtml = dayDiffSegment
+                    ? `${messageHtml}${dayDiffSegment}`
+                    : messageHtml;
+            }
+        } else {
+            const fallbackIncome = Math.round(toFiniteNumber(displaySummary?.totalIncome));
+            if (Number.isFinite(fallbackIncome)) {
+                const formattedFallback = fallbackIncome.toLocaleString('sv-SE');
+                summaryMessageHtml = `Totala hushållsinkomsten blir <strong>${formattedFallback} sek</strong>.`;
+            }
+        }
+
+        if (summaryMessageHtml) {
+            const summaryNote = document.createElement('p');
+            summaryNote.className = 'strategy-summary-note';
+            summaryNote.innerHTML = summaryMessageHtml;
+            box.appendChild(summaryNote);
+        }
+
+        const detailsContainer = document.createElement('div');
+        detailsContainer.className = 'strategy-details';
+        if (isMobileView) {
+            detailsContainer.classList.add('collapsed');
+        }
+
         const list = document.createElement('ul');
         list.className = 'strategy-metrics';
 
@@ -1630,8 +1740,8 @@ export function renderGanttChart(
             )
         );
 
-        box.appendChild(list);
-        box.appendChild(
+        detailsContainer.appendChild(list);
+        detailsContainer.appendChild(
             createDaysBlock(
                 'Använda dagar',
                 displaySummary.usedDays,
@@ -1639,7 +1749,7 @@ export function renderGanttChart(
                 { forceNeutral: useBaselineForDisplay, blockType: 'used' }
             )
         );
-        box.appendChild(
+        detailsContainer.appendChild(
             createDaysBlock(
                 'Återstående dagar',
                 displaySummary.remainingDays,
@@ -1648,93 +1758,46 @@ export function renderGanttChart(
             )
         );
 
-        if (baselineIncomeTotal != null) {
-            const strategyIncomeTotal = useBaselineForDisplay
-                ? baselineIncomeTotal
-                : Math.round(toFiniteNumber(summary.totalIncome));
-            if (Number.isFinite(strategyIncomeTotal)) {
-                const incomeNote = document.createElement('div');
-                incomeNote.className = 'strategy-income-note';
-
-                let dayDiffSegment = '';
-                if (baselineSummary) {
-                    const baselineRemainingTotal = Math.round(toFiniteNumber(baselineSummary.totalRemainingDays));
-                    const strategyRemainingTotal = useBaselineForDisplay
-                        ? baselineRemainingTotal
-                        : Math.round(toFiniteNumber(summary.totalRemainingDays));
-                    if (
-                        Number.isFinite(baselineRemainingTotal) &&
-                        Number.isFinite(strategyRemainingTotal)
-                    ) {
-                        const diffDays = useBaselineForDisplay
-                            ? 0
-                            : strategyRemainingTotal - baselineRemainingTotal;
-                        let diffClass = 'neutral';
-                        let diffLabel = '0 dagar';
-                        if (diffDays > 0) {
-                            diffClass = 'positive';
-                            diffLabel = `+${Math.abs(diffDays).toLocaleString('sv-SE')} dagar`;
-                        } else if (diffDays < 0) {
-                            diffClass = 'negative';
-                            diffLabel = `−${Math.abs(diffDays).toLocaleString('sv-SE')} dagar`;
-                        }
-                        dayDiffSegment = ` Antalet dagar förändras med <span class="days-diff ${diffClass}">${diffLabel}</span>.`;
-                    }
-                }
-
-                const formattedIncomeTotal = strategyIncomeTotal.toLocaleString('sv-SE');
-                let messageHtml = '';
-
-                if (useBaselineForDisplay) {
-                    if (boxData.type === 'remainingDays') {
-                        const parent1Remaining = Math.round(
-                            toNonNegative(displaySummary?.remainingDays?.parent1?.income)
-                        );
-                        const parent2Remaining = Math.round(
-                            toNonNegative(displaySummary?.remainingDays?.parent2?.income)
-                        );
-                        const totalSavedDays = parent1Remaining + parent2Remaining;
-                        const savedLabel = `${totalSavedDays.toLocaleString('sv-SE')} dagar`;
-                        messageHtml = `Denna strategi ger <span class="income-diff positive">den totala nettoinkomsten ${formattedIncomeTotal} sek</span>.<br>Med detta upplägg <span class="days-diff positive">sparar du ${savedLabel}</span>.`;
-                    } else {
-                        messageHtml = `Denna strategi ger <span class="income-diff positive">den totala nettoinkomsten ${formattedIncomeTotal} sek</span>.`;
-                    }
-                    dayDiffSegment = '';
-                } else if (strategyIncomeTotal === baselineIncomeTotal) {
-                    messageHtml = `Denna strategi ger samma totala inkomst (${formattedIncomeTotal} sek) som ditt nuvarande val.`;
-                } else {
-                    const diffValue = strategyIncomeTotal - baselineIncomeTotal;
-                    const signClass = diffValue > 0 ? 'positive' : 'negative';
-                    const signLabel = diffValue > 0 ? '+' : '−';
-                    const diffText = `${signLabel}${Math.abs(diffValue).toLocaleString('sv-SE')} sek`;
-                    messageHtml = `Totala hushållsinkomsten blir <strong>${formattedIncomeTotal} sek</strong> med den här strategin, vilket är <span class="income-diff ${signClass}">${diffText}</span> jämfört med ditt nuvarande val.`;
-                }
-
-                incomeNote.innerHTML = dayDiffSegment
-                    ? `${messageHtml}${dayDiffSegment}`
-                    : messageHtml;
-                box.appendChild(incomeNote);
-            }
+        if (summaryMessageHtml) {
+            const incomeNote = document.createElement('div');
+            incomeNote.className = 'strategy-income-note';
+            incomeNote.innerHTML = summaryMessageHtml;
+            detailsContainer.appendChild(incomeNote);
         }
 
-        let actionElement = null;
         if (actionNoteText) {
             const note = document.createElement('p');
             note.className = 'strategy-best-note';
             note.textContent = actionNoteText;
-            actionElement = note;
-        }
-
-        if (!actionElement) {
+            box.appendChild(note);
+        } else {
             const applyButton = document.createElement('button');
             applyButton.type = 'button';
             applyButton.className = 'strategy-use-btn';
             applyButton.textContent = 'Använd';
             applyButton.addEventListener('click', () => applySuggestedPlan(boxData));
-            actionElement = applyButton;
+            detailsContainer.appendChild(applyButton);
         }
 
-        box.appendChild(actionElement);
+        const toggleButton = document.createElement('button');
+        toggleButton.type = 'button';
+        toggleButton.className = 'strategy-details-toggle';
+
+        const updateToggleState = (expanded) => {
+            toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            toggleButton.textContent = expanded ? 'Dölj detaljer' : 'Visa detaljer';
+            detailsContainer.classList.toggle('collapsed', !expanded);
+        };
+
+        updateToggleState(!isMobileView);
+
+        toggleButton.addEventListener('click', () => {
+            const isExpanded = !detailsContainer.classList.contains('collapsed');
+            updateToggleState(!isExpanded);
+        });
+
+        box.appendChild(toggleButton);
+        box.appendChild(detailsContainer);
 
         return box;
     };

--- a/static/index.js
+++ b/static/index.js
@@ -15,7 +15,7 @@ import {
     calculateParentalLeaveDays
 } from './calculations.js';
 import {
-    updateProgress, setupInfoBoxToggle,
+    updateProgress, setupInfoBoxToggle, setupHelpTooltips,
     generateParentSection, setupStrategyToggle, updateMonthlyBox
 } from './ui.js';
 import { renderGanttChart } from './chart.js';
@@ -36,6 +36,7 @@ function initializeForm() {
     // Setup strategy and info boxes
     setupStrategyToggle();
     setupInfoBoxToggle();
+    setupHelpTooltips();
 
     const birthDateInput = document.getElementById('barn-datum');
     if (birthDateInput && !birthDateInput.value) {
@@ -60,6 +61,7 @@ function setupEventListeners() {
 
     // Dropdown listeners for uttag
     setupDropdownListeners();
+    setupHelpTooltips();
 
     // Leave distribution slider
     setupLeaveSlider();
@@ -142,6 +144,7 @@ function handleFormSubmit(e) {
 
     // Reinitialize info box toggles for dynamically added content
     setupInfoBoxToggle();
+    setupHelpTooltips();
 
     // Store global state for optimization
     window.appState = {
@@ -196,6 +199,9 @@ function setupDropdownListeners() {
                 parent1Days
             );
         };
+        if (window.appState) {
+            dropdown1.dispatchEvent(new Event('change'));
+        }
     }
 
     if (dropdown2) {
@@ -209,6 +215,9 @@ function setupDropdownListeners() {
                 parent2Days
             );
         };
+        if (window.appState) {
+            dropdown2.dispatchEvent(new Event('change'));
+        }
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -253,13 +253,69 @@ button:hover {
     display: inline-block;
     margin-left: 0.25rem;
     color: #00796b;
-    cursor: help;
+    cursor: pointer;
     border-bottom: 1px dotted #00796b;
+    touch-action: manipulation;
 }
 
 .help-tooltip:focus {
     outline: 2px solid #005f56;
     border-radius: 50%;
+}
+
+.mobile-tooltip-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(16, 24, 40, 0.45);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    z-index: 1200;
+}
+
+.mobile-tooltip-modal.open {
+    display: flex;
+}
+
+.mobile-tooltip-content {
+    background: #ffffff;
+    border-radius: 12px;
+    width: min(90vw, 420px);
+    max-width: 420px;
+    padding: 1.5rem;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-align: left;
+}
+
+.mobile-tooltip-text {
+    color: #344054;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.mobile-tooltip-close {
+    align-self: center;
+    background: #00796b;
+    color: #ffffff;
+    border: none;
+    border-radius: 999px;
+    padding: 0.5rem 1.75rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.mobile-tooltip-close:hover,
+.mobile-tooltip-close:focus-visible {
+    background-color: #005f56;
+    outline: none;
+    transform: translateY(-1px);
 }
 
 input[type="number"] {
@@ -1008,22 +1064,33 @@ input[type="number"] {
 .duration-info {
     font-size: 14px;
     color: #333;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .duration-info p {
     margin: 0;
 }
 
+.duration-label {
+    font-weight: 600;
+}
+
+.duration-text {
+    font-weight: 600;
+    color: #00796b;
+    font-size: 22px;
+}
+
 .duration-info .duration-value {
-    font-weight: bold;
-    color: #00796b; /* Match your color scheme */
-    font-size: 24px;
-    text-align: left;
+    font-weight: 700;
 }
 
 
 .uttag-container {
-    flex: 0 0 auto;
+    flex: 0 0 260px;
+    width: 100%;
     display: flex;
     flex-direction: column; /* Stack children vertically */
     align-items: flex-start;
@@ -1032,15 +1099,8 @@ input[type="number"] {
     background-color: #fff;
     border: 1px solid #ddd;
     border-radius: 5px;
-    max-width: 250px;
-}
-
-
-p.duration-text {
-    font-weight: bold;
-    color: #00796b; /* Match your color scheme */
-    font-size: 24px;
-    text-align: left;
+    max-width: 260px;
+    box-sizing: border-box;
 }
 canvas#gantt-canvas {
     height: 400px !important;
@@ -1428,13 +1488,15 @@ canvas#gantt-canvas {
     border-color: #0f172a;
 }
 #leave-slider-container {
-    margin-top: 16px;
+    margin: 16px auto 0;
     padding: 16px;
     border: 1px solid #e4e7ec;
     border-radius: 12px;
     background: #ffffff;
     box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
     transition: box-shadow 0.2s ease;
+    width: 100%;
+    max-width: 640px;
 }
 #leave-slider-container:hover {
     box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
@@ -1696,7 +1758,7 @@ canvas#gantt-canvas {
 .strategy-days-parent {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.25rem;
     color: #344054;
 }
 
@@ -1706,11 +1768,12 @@ canvas#gantt-canvas {
 }
 
 .strategy-days-detail {
-    font-size: 0.92rem;
+    font-size: clamp(0.78rem, 2.4vw, 0.9rem);
     padding-left: 0.75rem;
     display: flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.3rem;
+    white-space: nowrap;
 }
 
 .strategy-days-detail .detail-label {
@@ -1723,7 +1786,8 @@ canvas#gantt-canvas {
 
 .strategy-days-line {
     color: #344054;
-    font-size: 0.95rem;
+    font-size: clamp(0.8rem, 2.6vw, 0.95rem);
+    white-space: nowrap;
 }
 
 .days-total {
@@ -1770,6 +1834,42 @@ canvas#gantt-canvas {
     font-size: 0.95rem;
     color: #0f172a;
     border: 1px solid #b6e2d8;
+}
+
+.strategy-summary-note {
+    margin-top: 0.75rem;
+    padding: 0.5rem 0;
+    color: #344054;
+    font-size: 0.95rem;
+    line-height: 1.45;
+}
+
+.strategy-details {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.strategy-details.collapsed {
+    display: none;
+}
+
+.strategy-details-toggle {
+    margin-top: 0.75rem;
+    width: 100%;
+    padding: 0.6rem 1rem;
+    background-color: #f2f4f7;
+    color: #1d2939;
+    border: 1px solid #d0d5dd;
+    border-radius: 8px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.strategy-details-toggle:hover {
+    background-color: #e4e7ec;
 }
 
 .income-diff {
@@ -1833,6 +1933,7 @@ canvas#gantt-canvas {
     button,
     .toggle-btn {
         width: 100%;
+        font-size: 0.9rem;
     }
 
     form,
@@ -1840,8 +1941,38 @@ canvas#gantt-canvas {
         padding: 1rem;
     }
 
+    body {
+        font-size: 15px;
+    }
+
+    h1 {
+        font-size: 1.4rem;
+    }
+
+    label,
+    input,
+    select,
+    .info-text {
+        font-size: 0.9rem;
+    }
+
     .strategy-box {
         flex: 1 1 100%;
+        padding: 1rem;
+        text-align: center;
+    }
+
+    .strategy-box h4 {
+        font-size: 1rem;
+    }
+
+    .strategy-description,
+    .strategy-summary-note,
+    .strategy-income-note,
+    .strategy-details-toggle,
+    .strategy-metrics,
+    .strategy-best-note {
+        font-size: 0.9rem;
     }
 
     .strategy-box-wrapper {
@@ -1850,4 +1981,88 @@ canvas#gantt-canvas {
         gap: 1rem;
     }
 
+    #leave-slider-container {
+        padding: 12px;
+        max-width: 100%;
+    }
+
+    #leave-slider {
+        height: 12px;
+    }
+
+    .slider-values {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 6px;
+        font-size: 0.9rem;
+    }
+
+    .slider-labels span {
+        font-size: 0.85rem;
+    }
+
+    .monthly-wrapper {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .monthly-box,
+    .uttag-container {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .uttag-container {
+        align-items: center;
+        text-align: center;
+        padding: 16px;
+    }
+
+    .duration-info,
+    .duration-text {
+        text-align: center;
+    }
+
+    .duration-text {
+        font-size: 20px;
+    }
+
+    .monthly-row,
+    .monthly-total {
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        text-align: center;
+        white-space: normal;
+    }
+
+    .result-section,
+    .result-section h2,
+    .result-section h4,
+    .monthly-box h3,
+    .benefit-title,
+    .strategy-days-heading {
+        text-align: center;
+    }
+
+    .strategy-days-detail,
+    .strategy-days-line {
+        justify-content: center;
+    }
+
+    #strategy-group .toggle-options {
+        flex-wrap: nowrap;
+        gap: 8px;
+    }
+
+    #strategy-group .toggle-options .toggle-btn {
+        flex: 1 1 calc(50% - 8px);
+        max-width: none;
+        padding: 0.6rem 0.4rem;
+        font-size: 0.85rem;
+        width: auto;
+        min-width: 0;
+    }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,6 +128,7 @@
                     <span class="help-tooltip"
                           title="Ange din bruttolön innan skatt"
                           aria-label="Ange din bruttolön innan skatt"
+                          data-help="Ange din bruttolön innan skatt"
                           tabindex="0">?</span>
                 </label>
                 <input type="number" name="inkomst1" id="inkomst1"
@@ -138,6 +139,7 @@
                     <span class="help-tooltip"
                           title="Kollektivavtal kan ge extra föräldralön"
                           aria-label="Kollektivavtal kan ge extra föräldralön"
+                          data-help="Kollektivavtal kan ge extra föräldralön"
                           tabindex="0">?</span>
                 </label>
                 <div class="button-group" id="avtal-group-1">
@@ -151,6 +153,7 @@
                         <span class="help-tooltip"
                               title="Påverkar rätten till föräldralön"
                               aria-label="Påverkar rätten till föräldralön"
+                              data-help="Påverkar rätten till föräldralön"
                               tabindex="0">?</span>
                     </label>
                     <div class="button-group" id="anstallningstid-group-1">
@@ -169,6 +172,7 @@
                     <span class="help-tooltip"
                           title="Ange din partners bruttolön innan skatt"
                           aria-label="Ange din partners bruttolön innan skatt"
+                          data-help="Ange din partners bruttolön innan skatt"
                           tabindex="0">?</span>
                 </label>
                 <input type="number" name="inkomst2" id="inkomst2"
@@ -179,6 +183,7 @@
                     <span class="help-tooltip"
                           title="Kollektivavtal kan ge extra föräldralön"
                           aria-label="Kollektivavtal kan ge extra föräldralön"
+                          data-help="Kollektivavtal kan ge extra föräldralön"
                           tabindex="0">?</span>
                 </label>
                 <div class="button-group" id="avtal-group-2">
@@ -192,6 +197,7 @@
                         <span class="help-tooltip"
                               title="Påverkar rätten till föräldralön"
                               aria-label="Påverkar rätten till föräldralön"
+                              data-help="Påverkar rätten till föräldralön"
                               tabindex="0">?</span>
                     </label>
                     <div class="button-group" id="anstallningstid-group-2">


### PR DESCRIPTION
## Summary
- ensure the parental leave slider and uttag cards size correctly on mobile while defaulting the duration display to 7 dagar per vecka
- add reusable modal tooltips for touch devices and localize the minimum income legend to "Lägsta hushållsinkomst"
- center mobile headings and tighten strategy detail typography so expanded metrics remain legible

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68e64dfa8c30832b862ca5aeab8a332f