### PR TITLE
Refine parental leave wizard flow and mobile summary

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -20,6 +20,31 @@ import {
 } from './ui.js';
 import { renderGanttChart } from './chart.js';
 
+const stickyNettoEl = document.getElementById('sticky-netto');
+const stickyDaysEl = document.getElementById('sticky-days');
+const stickyCtaButton = document.getElementById('sticky-cta');
+
+function formatCurrency(value) {
+    if (!Number.isFinite(value)) return '–';
+    return `${Math.round(value).toLocaleString('sv-SE')} kr`;
+}
+
+function formatDays(value) {
+    if (!Number.isFinite(value)) return '–';
+    return value.toLocaleString('sv-SE');
+}
+
+function updateStickySummary(netValue, daysValue) {
+    if (stickyNettoEl) stickyNettoEl.textContent = formatCurrency(netValue);
+    if (stickyDaysEl) stickyDaysEl.textContent = formatDays(daysValue);
+}
+
+function resetStickySummary() {
+    updateStickySummary(Number.NaN, Number.NaN);
+}
+
+document.addEventListener('results-reset', resetStickySummary);
+
 // Initialize on DOM content loaded
 document.addEventListener('DOMContentLoaded', () => {
     initializeForm();
@@ -32,6 +57,9 @@ document.addEventListener('DOMContentLoaded', () => {
 function initializeForm() {
     // Initialize progress bar
     updateProgress(1);
+    document.body.dataset.resultsReady = 'false';
+    resetStickySummary();
+    document.dispatchEvent(new Event('results-reset'));
 
     // Setup strategy and info boxes
     setupStrategyToggle();
@@ -137,10 +165,8 @@ function handleFormSubmit(e) {
     }
 
     resultBlock.innerHTML = resultHtml;
-    document.getElementById('strategy-group').style.display = 'block';
-    document.getElementById('preferences-section').style.display = 'block';
     document.getElementById('optimize-btn').style.display = 'block';
-    updateProgress(7);
+    updateProgress(4);
 
     // Reinitialize info box toggles for dynamically added content
     setupInfoBoxToggle();
@@ -171,10 +197,23 @@ function handleFormSubmit(e) {
         planeradeBarn: plannedChildren
     };
 
+    const includePartner = vårdnad === 'gemensam' && beräknaPartner === 'ja';
     const leaveContainer = document.getElementById('leave-slider-container');
-    if (leaveContainer && (vårdnad === 'ensam' || beräknaPartner === 'nej')) {
-        leaveContainer.style.display = 'none';
+    if (leaveContainer) {
+        leaveContainer.style.display = includePartner ? 'block' : 'none';
     }
+
+    const hushallsBarnbidrag = vårdnad === 'ensam'
+        ? barnbidragResult.total
+        : barnbidragResult.total * 2;
+    const hushallsNetto = netto1 + (includePartner ? netto2 : 0) + hushallsBarnbidrag;
+    const totalRemainingDays = parent1IncomeDays + parent1LowDays +
+        (includePartner ? parent2IncomeDays + parent2LowDays : 0);
+
+    updateStickySummary(hushallsNetto, totalRemainingDays);
+    document.body.dataset.resultsReady = 'true';
+    if (stickyCtaButton) stickyCtaButton.textContent = 'Optimera';
+    document.dispatchEvent(new Event('results-ready'));
 
     // Update dropdown listeners for monthly boxes
     setupDropdownListeners();

--- a/static/style.css
+++ b/static/style.css
@@ -57,13 +57,49 @@ form {
     border-radius: 10px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     margin-bottom: 2rem;
-    position: relative;
+}
+
+form fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+form fieldset + fieldset {
+    margin-top: 2rem;
+}
+
+fieldset legend {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 1.5rem;
+    text-align: left;
+}
+
+.summary-intro {
+    font-size: 1rem;
+    color: #475467;
+    margin: 0;
 }
 
 label {
     display: block;
     margin-top: 1rem;
     font-weight: 600;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: auto;
+    margin: 0;
+    accent-color: #00796b;
 }
 
 input,
@@ -161,7 +197,8 @@ canvas {
     flex: 1;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
+    gap: 1.5rem;
 }
 
 
@@ -225,24 +262,33 @@ button:hover {
     margin-bottom: 0.5rem;
 }
 
-#back-btn {
-    background: none;
-    border: none;
-    color: #00796b;
-    font-weight: bold;
-    cursor: pointer;
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
+.wizard-nav {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.wizard-nav button {
+    flex: 1;
     width: auto;
-    margin: 0;
+    margin-top: 0;
+}
+
+.wizard-nav #back-btn {
+    background: transparent;
+    border: 1px solid #00796b;
+    color: #00796b;
+}
+
+.wizard-nav #back-btn:hover,
+.wizard-nav #back-btn:focus-visible {
+    background: #e0f2f1;
 }
 
 #calculate-btn {
     width: auto;
-    max-width: 300px;
-    margin: 1.5rem auto 3rem;
-    display: block;
+    max-width: none;
+    margin: 0;
 }
 
 #calculate-btn.hidden {
@@ -1408,11 +1454,65 @@ canvas#gantt-canvas {
 }
 
 .wizard-step.visible {
-    display: flex;
+    display: block;
 }
 
 .hidden {
     display: none;
+}
+
+.inline-error {
+    color: #d92d20;
+    font-size: 0.95rem;
+    margin-top: 0.75rem;
+}
+
+.mobile-sticky {
+    position: sticky;
+    bottom: 0;
+    padding: 12px max(16px, env(safe-area-inset-left)) 12px max(16px, env(safe-area-inset-right));
+    background: var(--surface, #fff);
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.08);
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    display: none;
+    gap: 12px;
+    z-index: 50;
+}
+
+.mobile-summary-content {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.mobile-summary-item {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.85rem;
+    color: #475467;
+}
+
+.summary-label {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.summary-value {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #101828;
+}
+
+.primary-cta {
+    width: 100%;
+    margin: 0;
+}
+
+@media (max-width: 768px) {
+    .mobile-sticky {
+        display: flex;
+        flex-direction: column;
+    }
 }
 
 /* Slider for distributing leave between parents */

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -2,175 +2,201 @@ import { updateProgress, setupToggleButtons } from './ui.js';
 
 /**
  * wizard.js - Sequential question wizard for the Föräldrapenningkalkylator
- * Handles navigation between questions, progress bar updates and back navigation.
+ * Handles navigation between wizard steps, progress bar updates and developer shortcuts.
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-    const sections = {
-        vardnad: document.querySelector('#vårdnad-group').closest('.wizard-step'),
-        partner: document.getElementById('partner-question'),
-        barnIdag: document.querySelector('#barn-tidigare-group').closest('.wizard-step'),
-        barnPlan: document.querySelector('#barn-planerade-group').closest('.wizard-step'),
-        inkomst1: document.getElementById('inkomst-avtal-1'),
-        inkomst2: document.getElementById('inkomst-block-2')
-    };
-
-    const stepSections = [
-        sections.vardnad,
-        sections.partner,
-        sections.barnIdag,
-        sections.barnPlan,
-        sections.inkomst1,
-        sections.inkomst2
-    ];
-
+    const steps = Array.from(document.querySelectorAll('fieldset.wizard-step'));
     const idx = {
-        vardnad: 0,
-        partner: 1,
-        barnIdag: 2,
-        barnPlan: 3,
-        inkomst1: 4,
-        inkomst2: 5,
-        calc: 6
+        household: 0,
+        income: 1,
+        preferences: 2,
+        summary: 3
     };
+
+    let currentIndex = idx.household;
+    let history = [];
+    let partnerActive = true;
 
     const calculateBtn = document.getElementById('calculate-btn');
     const backBtn = document.getElementById('back-btn');
-    const step6 = document.querySelector('.step-6');
-    let partnerSelected = false;
+    const nextBtn = document.getElementById('next-btn');
+    const stickyCTA = document.getElementById('sticky-cta');
+    const partnerCheckbox = document.getElementById('beräkna-partner-checkbox');
+    const partnerHidden = document.getElementById('beräkna-partner');
+    const partnerFields = document.querySelectorAll('[data-partner-field]');
+    const barnError = document.getElementById('barn-selection-error');
+    const progressSteps = document.querySelectorAll('#progress-bar .step');
 
-    let currentIndex = idx.vardnad;
-    let history = [];
-
-    function progressStepForIndex(i) {
-        if (i === idx.calc) return 7;
-        if (i <= idx.barnPlan) return i + 1;
-        if (i === idx.inkomst1) return 5;
-        if (i === idx.inkomst2) return 6;
-        return 1;
-    }
-
-    function showCurrent() {
-        stepSections.forEach(sec => sec.classList.remove('visible'));
-        calculateBtn.classList.add('hidden');
-
-        if (currentIndex !== idx.calc) {
-            stepSections[currentIndex]?.classList.add('visible');
+    function setPartnerFieldsVisible(visible) {
+        partnerActive = visible;
+        partnerFields.forEach(field => {
+            if (field instanceof HTMLElement) {
+                field.style.display = visible ? '' : 'none';
+            }
+        });
+        if (partnerHidden) {
+            partnerHidden.value = visible ? 'ja' : 'nej';
         }
-
-        updateProgress(progressStepForIndex(currentIndex));
-        backBtn.classList.toggle('hidden', history.length === 0);
-
-        if (currentIndex === idx.calc) calculateBtn.classList.remove('hidden');
     }
 
-    function goTo(nextIndex) {
-        history.push(currentIndex);
-        currentIndex = nextIndex;
-        showCurrent();
+    function updateStickyCtaLabel() {
+        if (!stickyCTA) return;
+        if (document.body.dataset.resultsReady === 'true') {
+            stickyCTA.textContent = 'Optimera';
+        } else {
+            stickyCTA.textContent = currentIndex === idx.summary ? 'Visa resultat' : 'Nästa steg';
+        }
+    }
+
+    function updateNavigation() {
+        backBtn.classList.toggle('hidden', currentIndex === idx.household);
+        const onSummary = currentIndex === idx.summary;
+        nextBtn.classList.toggle('hidden', onSummary);
+        calculateBtn.classList.toggle('hidden', !onSummary);
+        nextBtn.textContent = currentIndex === idx.preferences ? 'Gå till resultat' : 'Nästa steg';
+        updateStickyCtaLabel();
+    }
+
+    function displayStep(index, recordHistory = false) {
+        if (index < 0 || index >= steps.length) return;
+        if (recordHistory) {
+            history.push(currentIndex);
+        }
+        steps.forEach((step, i) => step.classList.toggle('visible', i === index));
+        currentIndex = index;
+        updateProgress(index + 1);
+        updateNavigation();
+    }
+
+    function validateStep(index) {
+        if (index === idx.household) {
+            const custodyInput = document.getElementById('vårdnad');
+            const custodyValue = custodyInput ? custodyInput.value : '';
+            const info = document.getElementById('vårdnad-info');
+            if (!custodyValue) {
+                if (info) info.textContent = 'Välj vårdnadstyp för att fortsätta.';
+                return false;
+            }
+            if (info && info.textContent) info.textContent = '';
+            const plannedValue = Number.parseInt(document.getElementById('barn-planerade').value, 10);
+            const validPlanned = Number.isFinite(plannedValue) && plannedValue > 0;
+            if (barnError) {
+                barnError.style.display = validPlanned ? 'none' : 'block';
+            }
+            return validPlanned;
+        }
+        if (index === idx.income) {
+            const income1 = document.getElementById('inkomst1');
+            if (income1 && (!income1.value || Number(income1.value) <= 0)) {
+                income1.focus();
+                if (typeof income1.reportValidity === 'function') {
+                    income1.reportValidity();
+                }
+                return false;
+            }
+        }
+        return true;
     }
 
     backBtn.addEventListener('click', () => {
         if (history.length === 0) return;
-        currentIndex = history.pop();
-        showCurrent();
+        const previous = history.pop();
+        displayStep(previous, false);
     });
 
-    const progressSteps = document.querySelectorAll('#progress-bar .step');
-    progressSteps.forEach((stepEl, i) => {
+    nextBtn.addEventListener('click', () => {
+        if (!validateStep(currentIndex)) return;
+        const nextIndex = Math.min(currentIndex + 1, steps.length - 1);
+        displayStep(nextIndex, true);
+    });
+
+    if (stickyCTA) {
+        stickyCTA.addEventListener('click', () => {
+            if (document.body.dataset.resultsReady === 'true') {
+                document.getElementById('optimize-btn')?.click();
+                return;
+            }
+            if (currentIndex !== idx.summary) {
+                nextBtn.click();
+            } else if (!calculateBtn.classList.contains('hidden')) {
+                calculateBtn.click();
+            }
+        });
+    }
+
+    progressSteps.forEach((stepEl, index) => {
         stepEl.addEventListener('click', () => {
-            if (!stepEl.classList.contains('completed') && !stepEl.classList.contains('active')) return;
-            const stepNum = i + 1;
-            const combined = history.concat(currentIndex);
-            let targetPos = -1;
-            for (let j = combined.length - 1; j >= 0; j--) {
-                if (progressStepForIndex(combined[j]) === stepNum) {
-                    targetPos = j;
-                    break;
-                }
-            }
-            if (targetPos !== -1) {
-                history = combined.slice(0, targetPos);
-                currentIndex = combined[targetPos];
-                showCurrent();
-            }
+            if (index > currentIndex) return;
+            displayStep(index, true);
         });
     });
 
-    showCurrent();
+    document.addEventListener('results-ready', updateStickyCtaLabel);
+    document.addEventListener('results-reset', updateStickyCtaLabel);
+
+    setPartnerFieldsVisible(true);
+    displayStep(idx.household);
 
     setupToggleButtons('vårdnad-group', 'vårdnad', value => {
-        if (value === 'ensam') {
-            partnerSelected = false;
-            document.getElementById('beräkna-partner').value = 'nej';
-            step6?.style.setProperty('display', 'none');
-            goTo(idx.barnIdag);
-        } else {
-            partnerSelected = true;
-            step6?.style.setProperty('display', 'flex');
-            goTo(idx.partner);
+        const isEnsam = value === 'ensam';
+        if (partnerCheckbox) {
+            partnerCheckbox.disabled = isEnsam;
+            if (isEnsam) {
+                partnerCheckbox.checked = false;
+                setPartnerFieldsVisible(false);
+            } else {
+                setPartnerFieldsVisible(partnerCheckbox.checked);
+            }
+        } else if (isEnsam) {
+            setPartnerFieldsVisible(false);
         }
     });
 
-    setupToggleButtons('partner-group', 'beräkna-partner', value => {
-        partnerSelected = value === 'ja';
-        if (partnerSelected) {
-            step6?.style.setProperty('display', 'flex');
-        } else {
-            step6?.style.setProperty('display', 'none');
-        }
-        goTo(idx.barnIdag);
-    });
+    if (partnerCheckbox) {
+        partnerCheckbox.addEventListener('change', () => {
+            if (partnerCheckbox.disabled) return;
+            setPartnerFieldsVisible(partnerCheckbox.checked);
+        });
+    }
 
     setupToggleButtons('barn-tidigare-group', 'barn-tidigare', () => {
-        goTo(idx.barnPlan);
+        if (barnError) barnError.style.display = 'none';
     });
-
     setupToggleButtons('barn-planerade-group', 'barn-planerade', () => {
-        goTo(idx.inkomst1);
+        if (barnError) barnError.style.display = 'none';
     });
 
     setupToggleButtons('avtal-group-1', 'har-avtal-1', value => {
         const container = document.getElementById('anstallningstid-container-1');
+        if (!container) return;
         if (value === 'ja') {
             container.style.display = 'block';
         } else {
             container.style.display = 'none';
-            document.getElementById('anstallningstid-1').value = '';
-            if (partnerSelected) {
-                goTo(idx.inkomst2);
-            } else {
-                goTo(idx.calc);
-            }
+            const input = document.getElementById('anstallningstid-1');
+            if (input) input.value = '';
         }
     });
 
-    setupToggleButtons('anstallningstid-group-1', 'anstallningstid-1', () => {
-        if (partnerSelected) {
-            goTo(idx.inkomst2);
-        } else {
-            goTo(idx.calc);
-        }
-    });
+    setupToggleButtons('anstallningstid-group-1', 'anstallningstid-1');
 
     setupToggleButtons('avtal-group-2', 'har-avtal-2', value => {
         const container = document.getElementById('anstallningstid-container-2');
-        if (value === 'ja') {
+        if (!container) return;
+        if (value === 'ja' && partnerActive) {
             container.style.display = 'block';
         } else {
             container.style.display = 'none';
-            document.getElementById('anstallningstid-2').value = '';
-            goTo(idx.calc);
+            const input = document.getElementById('anstallningstid-2');
+            if (input) input.value = '';
         }
     });
 
-    setupToggleButtons('anstallningstid-group-2', 'anstallningstid-2', () => {
-        goTo(idx.calc);
-    });
+    setupToggleButtons('anstallningstid-group-2', 'anstallningstid-2');
 
     const toggleInputMap = {
         'vårdnad-group': 'vårdnad',
-        'partner-group': 'beräkna-partner',
         'barn-tidigare-group': 'barn-tidigare',
         'barn-planerade-group': 'barn-planerade',
         'avtal-group-1': 'har-avtal-1',
@@ -202,17 +228,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function resetFormState() {
-        const toggleGroups = [
-            'vårdnad-group',
-            'partner-group',
-            'barn-tidigare-group',
-            'barn-planerade-group',
-            'avtal-group-1',
-            'anstallningstid-group-1',
-            'avtal-group-2',
-            'anstallningstid-group-2'
-        ];
-        toggleGroups.forEach(groupId => applyToggleValue(groupId, null));
+        Object.keys(toggleInputMap).forEach(groupId => applyToggleValue(groupId, null));
 
         const inputsToClear = [
             'inkomst1',
@@ -221,11 +237,9 @@ document.addEventListener('DOMContentLoaded', () => {
             'ledig-tid-2',
             'min-inkomst'
         ];
-        inputsToClear.forEach(inputId => {
-            const input = document.getElementById(inputId);
-            if (input) {
-                input.value = '';
-            }
+        inputsToClear.forEach(id => {
+            const input = document.getElementById(id);
+            if (input) input.value = '';
         });
 
         const container1 = document.getElementById('anstallningstid-container-1');
@@ -233,11 +247,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const container2 = document.getElementById('anstallningstid-container-2');
         if (container2) container2.style.display = 'none';
 
-        step6?.style.setProperty('display', 'none');
-        partnerSelected = false;
+        if (partnerCheckbox) {
+            partnerCheckbox.disabled = false;
+            partnerCheckbox.checked = true;
+        }
+        setPartnerFieldsVisible(true);
+        document.body.dataset.resultsReady = 'false';
+        document.dispatchEvent(new Event('results-reset'));
         history = [];
-        currentIndex = idx.vardnad;
-        showCurrent();
+        displayStep(idx.household);
     }
 
     function employmentOptionForParent(parent) {
@@ -269,12 +287,13 @@ document.addEventListener('DOMContentLoaded', () => {
             : (typeof partnerFallback === 'boolean' ? partnerFallback : true);
         const parents = Array.isArray(family.parents) ? family.parents : [];
         const hasSecondParent = parents.length > 1;
-        partnerSelected = custodyValue === 'gemensam' && shouldIncludePartner && hasSecondParent;
+        const includePartner = custodyValue === 'gemensam' && shouldIncludePartner && hasSecondParent;
 
-        const partnerValue = partnerSelected ? 'ja' : 'nej';
-        applyToggleValue('partner-group', partnerValue);
-        document.getElementById('beräkna-partner').value = partnerValue;
-        step6?.style.setProperty('display', partnerSelected ? 'flex' : 'none');
+        if (partnerCheckbox) {
+            partnerCheckbox.disabled = custodyValue === 'ensam';
+            partnerCheckbox.checked = includePartner;
+        }
+        setPartnerFieldsVisible(includePartner);
 
         const existingChildren = family.barn?.befintliga ?? 0;
         applyToggleValue('barn-tidigare-group', existingChildren.toString());
@@ -282,16 +301,12 @@ document.addEventListener('DOMContentLoaded', () => {
         applyToggleValue('barn-planerade-group', plannedChildren.toString());
 
         const parent1 = parents[0] || {};
-        const parent2 = partnerSelected ? parents[1] || {} : null;
+        const parent2 = includePartner ? parents[1] || {} : null;
 
         const income1Input = document.getElementById('inkomst1');
         const income2Input = document.getElementById('inkomst2');
-        if (income1Input) {
-            income1Input.value = parent1.salary_sek_per_month ?? '';
-        }
-        if (income2Input) {
-            income2Input.value = parent2?.salary_sek_per_month ?? '';
-        }
+        if (income1Input) income1Input.value = parent1.salary_sek_per_month ?? '';
+        if (income2Input) income2Input.value = parent2?.salary_sek_per_month ?? '';
 
         const minIncomeInput = document.getElementById('min-inkomst');
         if (minIncomeInput) {
@@ -314,11 +329,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const avtal2Value = parent2?.kollektivavtal ? 'ja' : 'nej';
-        applyToggleValue('avtal-group-2', partnerSelected ? avtal2Value : null);
+        applyToggleValue('avtal-group-2', includePartner ? avtal2Value : null);
         const container2 = document.getElementById('anstallningstid-container-2');
         const employment2 = employmentOptionForParent(parent2);
         if (container2) {
-            if (partnerSelected && avtal2Value === 'ja' && employment2) {
+            if (includePartner && avtal2Value === 'ja' && employment2) {
                 container2.style.display = 'block';
                 applyToggleValue('anstallningstid-group-2', employment2);
             } else {
@@ -327,17 +342,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
 
-        const historyPath = [idx.vardnad];
-        if (custodyValue === 'gemensam') {
-            historyPath.push(idx.partner);
-        }
-        historyPath.push(idx.barnIdag, idx.barnPlan, idx.inkomst1);
-        if (partnerSelected) {
-            historyPath.push(idx.inkomst2);
-        }
-        history = [...historyPath];
-        currentIndex = idx.calc;
-        showCurrent();
+        history = [idx.household, idx.income, idx.preferences];
+        displayStep(idx.summary, false);
     }
 
     const devFamilyButtons = document.querySelectorAll('.dev-family-btn');

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,46 +15,28 @@
     <div class="container">
         <div id="progress-bar">
             <div class="step step-1 active">
-                <div class="step-circle"><i class="fa-solid fa-people-roof"></i></div>
-                <span class="step-label">Vårdnad</span>
+                <div class="step-circle"><i class="fa-solid fa-house-chimney"></i></div>
+                <span class="step-label">Hushåll &amp; barn</span>
             </div>
             <div class="step step-2">
-                <div class="step-circle"><i class="fa-solid fa-user-plus"></i></div>
-                <span class="step-label">Beräkna för partner?</span>
+                <div class="step-circle"><i class="fa-solid fa-coins"></i></div>
+                <span class="step-label">Inkomster &amp; avtal</span>
             </div>
             <div class="step step-3">
-                <div class="step-circle"><i class="fa-solid fa-children"></i></div>
-                <span class="step-label">Antal barn idag</span>
+                <div class="step-circle"><i class="fa-solid fa-sliders"></i></div>
+                <span class="step-label">Preferenser</span>
             </div>
             <div class="step step-4">
-                <div class="step-circle"><i class="fa-solid fa-baby-carriage"></i></div>
-                <span class="step-label">Antal barn planerade</span>
-            </div>
-            <div class="step step-5">
-                <div class="step-circle"><i class="fa-solid fa-sack-dollar"></i></div>
-                <span class="step-label">Inkomst förälder 1</span>
-            </div>
-            <div class="step step-6">
-                <div class="step-circle"><i class="fa-solid fa-hand-holding-dollar"></i></div>
-                <span class="step-label">Inkomst förälder 2</span>
-            </div>
-            <div class="step step-7">
-                <div class="step-circle"><i class="fa-solid fa-calculator"></i></div>
-                <span class="step-label">Beräkna</span>
-            </div>
-            <div class="step step-8">
                 <div class="step-circle"><i class="fa-solid fa-chart-line"></i></div>
-                <span class="step-label">Optimera</span>
+                <span class="step-label">Resultat</span>
             </div>
         </div>
         
         <h1>Föräldrapenningkalkylator</h1>
         
         <form id="calc-form">
-            <button type="button" id="back-btn" class="hidden back-btn">&larr; Tillbaka</button>
-
-            <div class="form-section wizard-step" id="custody-step">
-                <!-- Development shortcuts: remove this block when no longer needed -->
+            <fieldset class="wizard-step visible" id="step-household">
+                <legend>Hushåll &amp; barn</legend>
                 <div class="wizard-first-step-layout">
                     <div class="dev-shortcuts" aria-hidden="true">
                         <button type="button" class="dev-family-btn" data-family-index="0">2 parents, 3 kids, medium income</button>
@@ -67,224 +49,224 @@
                         <button type="button" class="dev-family-btn" data-family-index="7">2 parents, twins on the way, mixed income</button>
                     </div>
                     <div class="wizard-first-step-content">
-                        <div class="question-icon"><i class="fa-solid fa-people-roof"></i></div>
-                        <label for="vårdnad">Har du Gemensam eller Ensam vårdnad?</label>
-                        <div class="button-group" id="vårdnad-group">
-                            <button type="button" class="vårdnad-btn toggle-btn" data-value="gemensam">Gemensam vårdnad</button>
-                            <button type="button" class="vårdnad-btn toggle-btn" data-value="ensam">Ensam vårdnad</button>
+                        <div class="form-section">
+                            <div class="question-icon"><i class="fa-solid fa-people-roof"></i></div>
+                            <label for="vårdnad">Har du Gemensam eller Ensam vårdnad?</label>
+                            <div class="button-group" id="vårdnad-group">
+                                <button type="button" class="vårdnad-btn toggle-btn" data-value="gemensam">Gemensam vårdnad</button>
+                                <button type="button" class="vårdnad-btn toggle-btn" data-value="ensam">Ensam vårdnad</button>
+                            </div>
+                            <input type="hidden" name="vårdnad" id="vårdnad" value="">
+                            <p id="vårdnad-info" class="info-text"></p>
                         </div>
-                        <input type="hidden" name="vårdnad" id="vårdnad" value="">
-                        <p id="vårdnad-info" class="info-text"></p>
+                        <div class="form-section">
+                            <div class="question-icon"><i class="fa-solid fa-user-plus"></i></div>
+                            <label for="beräkna-partner-checkbox" class="checkbox-label">
+                                <input type="checkbox" id="beräkna-partner-checkbox" checked>
+                                Beräkna föräldrapenning för partner
+                            </label>
+                            <input type="hidden" name="beräkna_partner" id="beräkna-partner" value="ja">
+                        </div>
+                        <div class="form-section">
+                            <div class="question-icon"><i class="fa-solid fa-children"></i></div>
+                            <label>Hur många barn har du/ni sedan tidigare?</label>
+                            <div class="button-group barnval" id="barn-tidigare-group">
+                                <button type="button" class="toggle-btn" data-value="0">0</button>
+                                <button type="button" class="toggle-btn" data-value="1">1</button>
+                                <button type="button" class="toggle-btn" data-value="2">2</button>
+                                <button type="button" class="toggle-btn" data-value="3">3</button>
+                                <button type="button" class="toggle-btn" data-value="4">4</button>
+                                <button type="button" class="toggle-btn" data-value="5">5</button>
+                                <button type="button" class="toggle-btn" data-value="6">6</button>
+                            </div>
+                            <input type="hidden" id="barn-tidigare" value="0">
+                        </div>
+                        <div class="form-section">
+                            <div class="question-icon"><i class="fa-solid fa-baby-carriage"></i></div>
+                            <label>Hur många fler barn planerar du/ni att få?</label>
+                            <div class="button-group barnval" id="barn-planerade-group">
+                                <button type="button" class="toggle-btn" data-value="1">1</button>
+                                <button type="button" class="toggle-btn" data-value="2">2</button>
+                                <button type="button" class="toggle-btn" data-value="3">3</button>
+                                <button type="button" class="toggle-btn" data-value="4">4</button>
+                                <button type="button" class="toggle-btn" data-value="5">5</button>
+                                <button type="button" class="toggle-btn" data-value="6">6</button>
+                            </div>
+                            <input type="hidden" id="barn-planerade" value="0">
+                        </div>
                     </div>
                 </div>
-            </div>
-
-            <div id="partner-question" class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-user-plus"></i></div>
-                <label for="beräkna-partner">Vill du beräkna föräldrapenning för din partner också?</label>
-                <div class="button-group" id="partner-group">
-                    <button type="button" class="toggle-btn" data-value="ja">Ja</button>
-                    <button type="button" class="toggle-btn" data-value="nej">Nej</button>
+                <div id="barn-selection-error" class="inline-error" role="alert" aria-live="assertive" style="display: none;">
+                    Vänligen välj både antal barn idag och antal planerade barn.
                 </div>
-                <input type="hidden" name="beräkna_partner" id="beräkna-partner" value="">
-            </div>
+            </fieldset>
 
-            <div class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-children"></i></div>
-                <label>Hur många barn har du/ni sedan tidigare?</label>
-                <div class="button-group barnval" id="barn-tidigare-group">
-                    <button type="button" class="toggle-btn" data-value="0">0</button>
-                    <button type="button" class="toggle-btn" data-value="1">1</button>
-                    <button type="button" class="toggle-btn" data-value="2">2</button>
-                    <button type="button" class="toggle-btn" data-value="3">3</button>
-                    <button type="button" class="toggle-btn" data-value="4">4</button>
-                    <button type="button" class="toggle-btn" data-value="5">5</button>
-                    <button type="button" class="toggle-btn" data-value="6">6</button>
-                </div>
-                <input type="hidden" id="barn-tidigare" value="0">
-            </div>
-
-            <div class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-baby-carriage"></i></div>
-                <label>Hur många fler barn planerar du/ni att få?</label>
-                <div class="button-group barnval" id="barn-planerade-group">
-                    <button type="button" class="toggle-btn" data-value="1">1</button>
-                    <button type="button" class="toggle-btn" data-value="2">2</button>
-                    <button type="button" class="toggle-btn" data-value="3">3</button>
-                    <button type="button" class="toggle-btn" data-value="4">4</button>
-                    <button type="button" class="toggle-btn" data-value="5">5</button>
-                    <button type="button" class="toggle-btn" data-value="6">6</button>
-                </div>
-                <input type="hidden" id="barn-planerade" value="0">
-            </div>
-            <div id="barn-selection-error" style="color: red; display: none; margin-top: 10px;">
-                Vänligen välj både antal barn idag och antal barn du planerar att ha.
-            </div>
-
-            <div class="form-section wizard-step" id="inkomst-avtal-1">
-                <div class="question-icon"><i class="fa-solid fa-sack-dollar"></i></div>
-                <label for="inkomst1">
-                    Vad är din månadsinkomst före skatt?
-                    <span class="help-tooltip"
-                          title="Ange din bruttolön innan skatt"
-                          aria-label="Ange din bruttolön innan skatt"
-                          data-help="Ange din bruttolön innan skatt"
-                          tabindex="0">?</span>
-                </label>
-                <input type="number" name="inkomst1" id="inkomst1"
-                       placeholder="30000 kr" required>
-                <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
-                <label for="har-avtal-1">
-                    Har du kollektivavtal?
-                    <span class="help-tooltip"
-                          title="Kollektivavtal kan ge extra föräldralön"
-                          aria-label="Kollektivavtal kan ge extra föräldralön"
-                          data-help="Kollektivavtal kan ge extra föräldralön"
-                          tabindex="0">?</span>
-                </label>
-                <div class="button-group" id="avtal-group-1">
-                    <button type="button" class="toggle-btn" data-value="ja">Ja</button>
-                    <button type="button" class="toggle-btn" data-value="nej">Nej</button>
-                </div>
-                <input type="hidden" name="har_avtal_1" id="har-avtal-1" value="">
-                <div id="anstallningstid-container-1" style="display: none;">
-                    <label for="anstallningstid-1">
-                        Hur länge har du varit anställd på din nuvarande arbetsplats?
+            <fieldset class="wizard-step" id="step-income">
+                <legend>Inkomster &amp; avtal</legend>
+                <div class="form-section" id="inkomst-avtal-1">
+                    <div class="question-icon"><i class="fa-solid fa-sack-dollar"></i></div>
+                    <label for="inkomst1">
+                        Vad är din månadsinkomst före skatt?
                         <span class="help-tooltip"
-                              title="Påverkar rätten till föräldralön"
-                              aria-label="Påverkar rätten till föräldralön"
-                              data-help="Påverkar rätten till föräldralön"
+                              title="Ange din bruttolön innan skatt"
+                              aria-label="Ange din bruttolön innan skatt"
+                              data-help="Ange din bruttolön innan skatt"
                               tabindex="0">?</span>
                     </label>
-                    <div class="button-group" id="anstallningstid-group-1">
-                        <button type="button" class="toggle-btn" data-value="0-5">0-5 månader</button>
-                        <button type="button" class="toggle-btn" data-value="6-12">6 månader - 1 år</button>
-                        <button type="button" class="toggle-btn" data-value=">1">&gt; 1 år</button>
-                    </div>
-                    <input type="hidden" name="anstallningstid_1" id="anstallningstid-1" value="">
-                </div>
-            </div>
-
-            <div id="inkomst-block-2" class="form-section wizard-step">
-                <div class="question-icon"><i class="fa-solid fa-hand-holding-dollar"></i></div>
-                <label for="inkomst2">
-                    Månadsinkomst förälder 2 (före skatt):
-                    <span class="help-tooltip"
-                          title="Ange din partners bruttolön innan skatt"
-                          aria-label="Ange din partners bruttolön innan skatt"
-                          data-help="Ange din partners bruttolön innan skatt"
-                          tabindex="0">?</span>
-                </label>
-                <input type="number" name="inkomst2" id="inkomst2"
-                       placeholder="30000 kr">
-                <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
-                <label for="har-avtal-2">
-                    Har din partner kollektivavtal?
-                    <span class="help-tooltip"
-                          title="Kollektivavtal kan ge extra föräldralön"
-                          aria-label="Kollektivavtal kan ge extra föräldralön"
-                          data-help="Kollektivavtal kan ge extra föräldralön"
-                          tabindex="0">?</span>
-                </label>
-                <div class="button-group" id="avtal-group-2">
-                    <button type="button" class="toggle-btn" data-value="ja">Ja</button>
-                    <button type="button" class="toggle-btn" data-value="nej">Nej</button>
-                </div>
-                <input type="hidden" name="har_avtal_2" id="har-avtal-2" value="">
-                <div id="anstallningstid-container-2" style="display: none;">
-                    <label for="anstallningstid-2">
-                        Hur länge har du varit anställd på din nuvarande arbetsplats?
+                    <input type="number" name="inkomst1" id="inkomst1"
+                           placeholder="30000 kr" required>
+                    <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
+                    <label for="har-avtal-1">
+                        Har du kollektivavtal?
                         <span class="help-tooltip"
-                              title="Påverkar rätten till föräldralön"
-                              aria-label="Påverkar rätten till föräldralön"
-                              data-help="Påverkar rätten till föräldralön"
+                              title="Kollektivavtal kan ge extra föräldralön"
+                              aria-label="Kollektivavtal kan ge extra föräldralön"
+                              data-help="Kollektivavtal kan ge extra föräldralön"
                               tabindex="0">?</span>
                     </label>
-                    <div class="button-group" id="anstallningstid-group-2">
-                        <button type="button" class="toggle-btn" data-value="0-5">0-5 månader</button>
-                        <button type="button" class="toggle-btn" data-value="6-12">6 månader - 1 år</button>
-                        <button type="button" class="toggle-btn" data-value=">1">&gt; 1 år</button>
+                    <div class="button-group" id="avtal-group-1">
+                        <button type="button" class="toggle-btn" data-value="ja">Ja</button>
+                        <button type="button" class="toggle-btn" data-value="nej">Nej</button>
                     </div>
-                    <input type="hidden" name="anstallningstid_2" id="anstallningstid-2" value="">
+                    <input type="hidden" name="har_avtal_1" id="har-avtal-1" value="">
+                    <div id="anstallningstid-container-1" style="display: none;">
+                        <label for="anstallningstid-1">
+                            Hur länge har du varit anställd på din nuvarande arbetsplats?
+                            <span class="help-tooltip"
+                                  title="Påverkar rätten till föräldralön"
+                                  aria-label="Påverkar rätten till föräldralön"
+                                  data-help="Påverkar rätten till föräldralön"
+                                  tabindex="0">?</span>
+                        </label>
+                        <div class="button-group" id="anstallningstid-group-1">
+                            <button type="button" class="toggle-btn" data-value="0-5">0-5 månader</button>
+                            <button type="button" class="toggle-btn" data-value="6-12">6 månader - 1 år</button>
+                            <button type="button" class="toggle-btn" data-value=">1">&gt; 1 år</button>
+                        </div>
+                        <input type="hidden" name="anstallningstid_1" id="anstallningstid-1" value="">
+                    </div>
                 </div>
-            </div>
 
-            <button type="submit" id="calculate-btn" class="hidden">Visa resultat</button>
+                <div id="inkomst-block-2" class="form-section" data-partner-field>
+                    <div class="question-icon"><i class="fa-solid fa-hand-holding-dollar"></i></div>
+                    <label for="inkomst2">
+                        Månadsinkomst förälder 2 (före skatt):
+                        <span class="help-tooltip"
+                              title="Ange din partners bruttolön innan skatt"
+                              aria-label="Ange din partners bruttolön innan skatt"
+                              data-help="Ange din partners bruttolön innan skatt"
+                              tabindex="0">?</span>
+                    </label>
+                    <input type="number" name="inkomst2" id="inkomst2"
+                           placeholder="30000 kr">
+                    <div class="question-icon"><i class="fa-solid fa-handshake"></i></div>
+                    <label for="har-avtal-2">
+                        Har din partner kollektivavtal?
+                        <span class="help-tooltip"
+                              title="Kollektivavtal kan ge extra föräldralön"
+                              aria-label="Kollektivavtal kan ge extra föräldralön"
+                              data-help="Kollektivavtal kan ge extra föräldralön"
+                              tabindex="0">?</span>
+                    </label>
+                    <div class="button-group" id="avtal-group-2">
+                        <button type="button" class="toggle-btn" data-value="ja">Ja</button>
+                        <button type="button" class="toggle-btn" data-value="nej">Nej</button>
+                    </div>
+                    <input type="hidden" name="har_avtal_2" id="har-avtal-2" value="">
+                    <div id="anstallningstid-container-2" style="display: none;">
+                        <label for="anstallningstid-2">
+                            Hur länge har din partner varit anställd?
+                            <span class="help-tooltip"
+                                  title="Påverkar rätten till föräldralön"
+                                  aria-label="Påverkar rätten till föräldralön"
+                                  data-help="Påverkar rätten till föräldralön"
+                                  tabindex="0">?</span>
+                        </label>
+                        <div class="button-group" id="anstallningstid-group-2">
+                            <button type="button" class="toggle-btn" data-value="0-5">0-5 månader</button>
+                            <button type="button" class="toggle-btn" data-value="6-12">6 månader - 1 år</button>
+                            <button type="button" class="toggle-btn" data-value=">1">&gt; 1 år</button>
+                        </div>
+                        <input type="hidden" name="anstallningstid_2" id="anstallningstid-2" value="">
+                    </div>
+                </div>
+            </fieldset>
+
+            <fieldset class="wizard-step" id="step-preferences">
+                <legend>Preferenser</legend>
+                <div class="form-section">
+                    <label>När är barnet beräknat?</label>
+                    <div class="date-picker-container">
+                        <input type="date" id="barn-datum" name="barn-datum" required>
+                    </div>
+                </div>
+                <div class="form-section">
+                    <label>Hur länge vill du/ni vara lediga? (månader)</label>
+                    <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
+                </div>
+                <div class="form-section" id="parent-ledig-tid" data-partner-field>
+                    <label>Hur länge vill din partner vara ledig? (månader)</label>
+                    <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
+                </div>
+                <div class="form-section">
+                    <label for="strategy">Välj strategi:</label>
+                    <div class="toggle-group" id="strategy-group">
+                        <div class="toggle-options">
+                            <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
+                            <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
+                        </div>
+                        <input type="hidden" id="strategy" value="longer">
+                    </div>
+                </div>
+            </fieldset>
+
+            <fieldset class="wizard-step" id="step-summary">
+                <legend>Resultat</legend>
+                <p class="summary-intro">Sammanfatta dina uppgifter och visa resultatet när du är redo.</p>
+            </fieldset>
+
+            <div class="wizard-nav">
+                <button type="button" id="back-btn" class="hidden back-btn">&larr; Tillbaka</button>
+                <button type="button" id="next-btn">Nästa steg</button>
+                <button type="submit" id="calculate-btn" class="hidden">Visa resultat</button>
+            </div>
         </form>
 
+        <div class="mobile-sticky" id="mobile-summary" aria-live="polite">
+            <div class="mobile-summary-content">
+                <div class="mobile-summary-item">
+                    <span class="summary-label">Prognos hushållsnetto / månad</span>
+                    <span class="summary-value" id="sticky-netto">–</span>
+                </div>
+                <div class="mobile-summary-item">
+                    <span class="summary-label">Återstående dagar</span>
+                    <span class="summary-value" id="sticky-days">–</span>
+                </div>
+            </div>
+            <button type="button" id="sticky-cta" class="primary-cta">Visa resultat</button>
+        </div>
+
         <div id="result-block"></div>
-        <div class="toggle-group" id="strategy-group" style="display: none;">
-            <label for="strategy">Välj strategi:</label>
-            <div class="toggle-options">
-                <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
-                <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
+        <div class="preference-group" id="leave-slider-container" style="display: none;">
+            <input type="range" id="leave-slider" min="0" max="0" value="0" step="1" list="leave-ticks">
+            <datalist id="leave-ticks"></datalist>
+            <div class="slider-labels">
+                <span id="slider-start">0</span>
+                <span id="slider-end">0</span>
             </div>
-            <input type="hidden" id="strategy" value="longer">
+            <div class="slider-values">
+                <span class="slider-value p1-value"><strong>Förälder 1:</strong> <span id="p1-months">0</span> månader</span>
+                <span class="slider-value p2-value"><strong>Förälder 2:</strong> <span id="p2-months">0</span> månader</span>
+            </div>
         </div>
-        
-        <div class="form-section" id="preferences-section" style="display: none;">
-            <h3>Preferenser för föräldraledighet</h3>
-            <div class="form-section">
-                <label>När är barnet beräknat?</label>
-                <div class="date-picker-container">
-                    <input type="date" id="barn-datum" name="barn-datum" required>
-                </div>
-            </div>
-            <div class="preference-group">
-                <label>Hur länge vill du/ni vara lediga? (månader)</label>
-                <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
-            </div>
-            <div class="preference-group" id="leave-slider-container" style="display: none;">
-                <input type="range" id="leave-slider" min="0" max="0" value="0" step="1" list="leave-ticks">
-                <datalist id="leave-ticks"></datalist>
-                <div class="slider-labels">
-                    <span id="slider-start">0</span>
-                    <span id="slider-end">0</span>
-                </div>
-                <div class="slider-values">
-                    <span class="slider-value p1-value"><strong>Förälder 1:</strong> <span id="p1-months">0</span> månader</span>
-                    <span class="slider-value p2-value"><strong>Förälder 2:</strong> <span id="p2-months">0</span> månader</span>
-                </div>
-            </div>
-            <div class="preference-group" id="parent-ledig-tid" style="display: none;">
-                <label>Hur länge vill din partner vara ledig? (månader)</label>
-                <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
-            </div>
-            <div class="preference-group">
-                <label>Vad är minimigränsen för hushållets månadsinkomst (netto)? (kr/månad)</label>
-                <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
-                <div id="min-income-error" style="color: red; display: none; margin-top: 10px;">
-                    Vänligen ange minimigräns för din månadsinkomst.
-                </div>
-                <div class="info-box">
-                    <div class="info-header">
-                        <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
-                        <span><strong>Typiska hushållsutgifter i Sverige</strong></span>
-                        <span class="info-arrow">▾</span>
-                    </div>
-                <div class="info-content">
-                    <p>För att hjälpa dig sätta en realistisk minimigräns, här är genomsnittliga månatliga utgifter för ett hushåll (SCB 2024, justerat för 2025):</p>
-                    <ul>
-                        <li><strong>Bostad (hyra/lån)</strong>: 8,000–12,000 kr (1–3 rum, varierar per stad)</li>
-                        <li><strong>El, vatten, värme, internet</strong>: 2,000–3,000 kr</li>
-                        <li><strong>Förskola (dagis)</strong>: Upp till 1,400 kr per barn (inkomstbaserat)</li>
-                        <li><strong>Mat</strong>: 4,000–6,000 kr (1–2 barn)</li>
-                        <li><strong>Transport</strong>: 1,500–3,000 kr (kollektivtrafik eller bil)</li>
-                        <li><strong>Övrigt (försäkring, kläder, fritid)</strong>: 2,000–4,000 kr</li>
-                    </ul>
-                    <p><strong>Totalt</strong>: ~18,000–29,000 kr/månad för en familj med 1–2 barn. Anpassa efter din situation, t.ex. Stockholm är dyrare än mindre orter.</p>
-                </div>
-            </div>
-            </div>
-            <div id="leave-duration-error" style="color: red; display: none; margin-top: 10px;">
-                Ogiltig ledighetslängd. Kontrollera antalet dagar och försök igen.
-            </div>
-            <button type="button" id="optimize-btn" style="display: none;">Optimera föräldraledighet</button>
+        <div id="leave-duration-error" style="color: red; display: none; margin-top: 10px;">
+            Ogiltig ledighetslängd. Kontrollera antalet dagar och försök igen.
         </div>
+        <button type="button" id="optimize-btn" style="display: none;">Optimera föräldraledighet</button>
         <div id="optimization-result" style="display: none;">
             <h3>Optimerat schema för föräldraledighet</h3>
             <div id="gantt-chart"></div>
-        <div id="calendar-container"  style="display: none;">
+            <div id="calendar-container"  style="display: none;">
 
                 <div class="blocks-container">
                     <h3>Disponibla Veckoblock</h3>


### PR DESCRIPTION
## Summary
- restructure the landing form into a four-step fieldset wizard with a partner checkbox and inline error messaging
- add a mobile sticky summary bar with CTA support and update styles for the revised navigation
- update wizard and main scripts to drive the new step logic and expose household metrics in the sticky summary

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e667a6a370832bb06ca6a025be5aa2