### PR TITLE
Fix duplicate includePartner declaration in index.js

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -229,7 +229,6 @@ function handleFormSubmit(e) {
         preferensTotalLedigTid: totalPreferensLedigTid
     };
 
-    const includePartner = vårdnad === 'gemensam' && beräknaPartner === 'ja';
     const leaveContainer = document.getElementById('leave-slider-container');
     if (leaveContainer) {
         leaveContainer.style.display = includePartner ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- remove the duplicate includePartner constant declaration in the results handler to prevent runtime syntax errors

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e6816f6560832ba7c9cfd79a480b24