### PR TITLE
Fix mobile wizard markup and adjust child selection styles

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -229,7 +229,6 @@ function handleFormSubmit(e) {
         preferensTotalLedigTid: totalPreferensLedigTid
     };
 
-    const includePartner = vårdnad === 'gemensam' && beräknaPartner === 'ja';
     const leaveContainer = document.getElementById('leave-slider-container');
     if (leaveContainer) {
         leaveContainer.style.display = includePartner ? 'block' : 'none';

--- a/static/style.css
+++ b/static/style.css
@@ -301,8 +301,8 @@ button:hover {
 }
 
 .button-group.barnval .toggle-btn.active {
-    background-color: #145847;
-    border-color: #0f3d33;
+    background-color: #00796b;
+    border-color: #005f56;
     color: #ffffff;
 }
 
@@ -335,7 +335,8 @@ button:hover {
 }
 
 .button-group.barnval .toggle-btn.active {
-    background-color: #1f5a58;
+    background-color: #00796b;
+    border-color: #005f56;
     color: #ffffff;
 }
 
@@ -2245,7 +2246,7 @@ canvas#gantt-canvas {
 
 
 @media (max-width: 600px) {
-    .button-group {
+    .button-group:not(.barnval) {
         flex-direction: column;
         align-items: stretch;
     }
@@ -2254,6 +2255,19 @@ canvas#gantt-canvas {
     .toggle-btn {
         width: 100%;
         font-size: 0.9rem;
+    }
+
+    .button-group.barnval {
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: center;
+        overflow-x: auto;
+    }
+
+    .button-group.barnval .toggle-btn {
+        flex: 0 0 40px;
+        min-width: 40px;
+        width: 40px;
     }
 
     form,

--- a/templates/index.html
+++ b/templates/index.html
@@ -247,50 +247,6 @@
                     <span class="summary-label">Återstående dagar</span>
                     <span class="summary-value" id="sticky-days">–</span>
                 </div>
-            </fieldset>
-
-            <fieldset class="wizard-step" id="step-preferences">
-                <legend>Preferenser</legend>
-                <div class="form-section">
-                    <label>När är barnet beräknat?</label>
-                    <div class="date-picker-container">
-                        <input type="date" id="barn-datum" name="barn-datum" required>
-                    </div>
-                </div>
-                <div class="form-section">
-                    <label>Hur länge vill du/ni vara lediga? (månader)</label>
-                    <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
-                </div>
-                <div class="form-section" id="parent-ledig-tid" data-partner-field>
-                    <label>Hur länge vill din partner vara ledig? (månader)</label>
-                    <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
-                </div>
-                <div class="form-section">
-                    <label for="min-inkomst">Minimi-netto för hushållet (kr/månad)</label>
-                    <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
-                    <div id="min-income-error" class="inline-error" role="alert" aria-live="assertive" style="display: none;"></div>
-                </div>
-                <div class="form-section">
-                    <label for="strategy">Välj strategi:</label>
-                    <div class="toggle-group" id="strategy-group">
-                        <div class="toggle-options">
-                            <button class="toggle-btn active" data-value="longer">Längre ledighet</button>
-                            <button class="toggle-btn" data-value="maximize">Maximera inkomst</button>
-                        </div>
-                        <input type="hidden" id="strategy" value="longer">
-                    </div>
-                </div>
-            </fieldset>
-
-            <fieldset class="wizard-step" id="step-summary">
-                <legend>Resultat</legend>
-                <p class="summary-intro">Sammanfatta dina uppgifter och visa resultatet när du är redo.</p>
-            </fieldset>
-
-            <div class="wizard-nav">
-                <button type="button" id="back-btn" class="hidden back-btn">&larr; Tillbaka</button>
-                <button type="button" id="next-btn">Nästa steg</button>
-                <button type="submit" id="calculate-btn" class="hidden">Visa resultat</button>
             </div>
             <button type="button" id="sticky-cta" class="primary-cta">Visa resultat</button>
         </div>


### PR DESCRIPTION
## Summary
- remove duplicate form sections from the mobile summary container so the sticky CTA and inputs behave correctly
- align child count selection active styling with the primary action color and keep the buttons horizontal on mobile breakpoints

## Testing
- curl -I http://127.0.0.1:5000/


------
https://chatgpt.com/codex/tasks/task_e_68e6816f6560832ba7c9cfd79a480b24