### PR TITLE
Refactor calculator flow to single-page setup

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -25,21 +25,9 @@ export function calculateParentalLeaveDays(vårdnadstyp, expectedChildren = 1) {
     const normalizedCustody = (vårdnadstyp || 'gemensam').toLowerCase() === 'ensam'
         ? 'ensam'
         : 'gemensam';
-    const parsedChildren = Number(expectedChildren);
-    const plannedChildren = Number.isFinite(parsedChildren)
-        ? Math.max(1, Math.round(parsedChildren))
-        : 1;
-
-    let totalIncomeDays = 390;
-    let totalLowDays = 90;
-
-    if (plannedChildren === 2) {
-        totalIncomeDays = 480;
-        totalLowDays = 180;
-    } else if (plannedChildren === 3) {
-        totalIncomeDays = 660;
-        totalLowDays = 180;
-    }
+    void expectedChildren; // kept for API compatibility
+    const totalIncomeDays = 390;
+    const totalLowDays = 90;
 
     const total = { incomeDays: totalIncomeDays, lowDays: totalLowDays };
 
@@ -302,17 +290,13 @@ export function beräknaNetto(inkomst, skattesats = 30) {
  * @returns {Object} Object with barnbidrag, tillägg, total, and details
  */
 export function beräknaBarnbidrag(totalBarn, ensamVårdnad) {
-    const bidragPerBarn = 1250;
-    const flerbarnstillägg = { 2: 150, 3: 730, 4: 1740, 5: 2990, 6: 4240 };
-    const barnbidrag = bidragPerBarn * totalBarn;
-    const tillägg = flerbarnstillägg[totalBarn] || 0;
-    const total = barnbidrag + tillägg;
-    const details = `${totalBarn} barn ger ${barnbidrag.toLocaleString()} kr barnbidrag${tillägg ? " + " + tillägg + " kr flerbarnstillägg" : ""} = <strong>${total.toLocaleString()} kr</strong>`;
+    void totalBarn;
+    void ensamVårdnad;
     return {
-        barnbidrag: ensamVårdnad ? barnbidrag : Math.round(barnbidrag / 2),
-        tillägg: ensamVårdnad ? tillägg : Math.round(tillägg / 2),
-        total: ensamVårdnad ? total : Math.round(total / 2),
-        details
+        barnbidrag: 0,
+        tillägg: 0,
+        total: 0,
+        details: ''
     };
 }
 
@@ -374,8 +358,8 @@ function optimizeParentalLeaveLegacy(preferences, inputs) {
         return severity;
     };
 
-    const barnbidrag = inputs.barnbidragPerPerson || 1250;
-    const tillägg = inputs.tilläggPerPerson || 75;
+    const barnbidrag = Number(inputs.barnbidragPerPerson) || 0;
+    const tillägg = Number(inputs.tilläggPerPerson) || 0;
 
     const inkomst1 = Number(inputs.inkomst1) || 0;
     const inkomst2 = Number(inputs.inkomst2) || 0;
@@ -1160,8 +1144,8 @@ function optimizeParentalLeaveParentalSalary(preferences, inputs) {
         return severity;
     };
 
-    const barnbidrag = inputs.barnbidragPerPerson || 1250;
-    const tillägg = inputs.tilläggPerPerson || 75;
+    const barnbidrag = Number(inputs.barnbidragPerPerson) || 0;
+    const tillägg = Number(inputs.tilläggPerPerson) || 0;
 
     const inkomst1 = Number(inputs.inkomst1) || 0;
     const inkomst2 = Number(inputs.inkomst2) || 0;

--- a/static/config.js
+++ b/static/config.js
@@ -19,7 +19,7 @@ export const förälder1MinDagar = 45; // Minimum reserved days for Parent 1
 export const förälder2MinDagar = 45; // Minimum reserved days for Parent 2
 
 // Benefits
-export const barnbidragPerPerson = 625; // Child allowance per person (SEK/month)
+export const barnbidragPerPerson = 0; // Child allowance per person (SEK/month)
 export const tilläggPerPerson = 0; // Additional allowance per person (SEK/month)
 
 // Constants
@@ -27,7 +27,7 @@ export const INCOME_CAP = 1250; // SEK/day max parental benefit
 export const MINIMUM_RATE = 180; // SEK/day minimum parental benefit
 export const GRUNDNIVÅ = 250; // SEK/day grundnivå for low income parents
 export const SGI_CAP = 49000; // Max monthly SGI
-export const DEFAULT_BARNBIDRAG = 625; // Default child allowance per person
+export const DEFAULT_BARNBIDRAG = 0; // Default child allowance per person
 export const PRISBASBELOPP = 58800; // Prisbasbelopp 2025 (SEK)
 
 // Default preferences

--- a/static/wizard.js
+++ b/static/wizard.js
@@ -1,64 +1,20 @@
-import { updateProgress, setupToggleButtons } from './ui.js';
+import { setupToggleButtons } from './ui.js';
 
 /**
- * wizard.js - Sequential question wizard for the Föräldrapenningkalkylator
- * Handles navigation between wizard steps, progress bar updates and developer shortcuts.
+ * wizard.js - Input helpers for the single-step Föräldrapenningkalkylator
+ * Handles partner visibility toggles and setup for button groups.
  */
-
 document.addEventListener('DOMContentLoaded', () => {
-    const steps = Array.from(document.querySelectorAll('fieldset.wizard-step'));
-    const idx = {
-        household: 0,
-        income: 1,
-        preferences: 2,
-        summary: 3
-    };
-
-    let currentIndex = idx.household;
-    let history = [];
-    let partnerActive = true;
-    let hasDisplayedInitially = false;
-
-    const calculateBtn = document.getElementById('calculate-btn');
-    const backBtn = document.getElementById('back-btn');
-    const nextBtn = document.getElementById('next-btn');
-    const stickyCTA = document.getElementById('sticky-cta');
-    const mobileSummary = document.getElementById('mobile-summary');
     const partnerCheckbox = document.getElementById('beräkna-partner-checkbox');
-    const partnerHidden = document.getElementById('beräkna-partner');
+    const partnerHiddenInput = document.getElementById('beräkna-partner');
     const partnerFields = document.querySelectorAll('[data-partner-field]');
-    const barnError = document.getElementById('barn-selection-error');
-    const progressSteps = document.querySelectorAll('#progress-bar .step');
-    const progressBar = document.getElementById('progress-bar');
-    const wizardForm = document.getElementById('calc-form');
+    const partnerInputs = document.querySelectorAll('[data-partner-field] input');
+    const employmentContainer2 = document.getElementById('anstallningstid-container-2');
+    const stickyCTA = document.getElementById('sticky-cta');
+    const optimizeButton = document.getElementById('optimize-btn');
+    const form = document.getElementById('calc-form');
 
-    const COMPACT_SCROLL_THRESHOLD = 120;
-    const mobileQuery = window.matchMedia('(max-width: 768px)');
-
-    const handleScroll = () => {
-        if (!progressBar) return;
-        if (!mobileQuery.matches) {
-            progressBar.classList.remove('compact');
-            return;
-        }
-        const shouldCompact = window.scrollY > COMPACT_SCROLL_THRESHOLD;
-        progressBar.classList.toggle('compact', shouldCompact);
-    };
-
-    const scrollToWizardTop = () => {
-        const target = wizardForm || document.querySelector('.container');
-        if (!target) return;
-        const rect = target.getBoundingClientRect();
-        const offset = Math.max(0, window.scrollY + rect.top - 32);
-        window.scrollTo({ top: offset, behavior: 'smooth' });
-    };
-
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    if (typeof mobileQuery.addEventListener === 'function') {
-        mobileQuery.addEventListener('change', handleScroll);
-    } else if (typeof mobileQuery.addListener === 'function') {
-        mobileQuery.addListener(handleScroll);
-    }
+    let partnerActive = partnerCheckbox ? partnerCheckbox.checked : false;
 
     function setPartnerFieldsVisible(visible) {
         partnerActive = visible;
@@ -67,150 +23,49 @@ document.addEventListener('DOMContentLoaded', () => {
                 field.style.display = visible ? '' : 'none';
             }
         });
-        if (partnerHidden) {
-            partnerHidden.value = visible ? 'ja' : 'nej';
+        if (partnerHiddenInput) {
+            partnerHiddenInput.value = visible ? 'ja' : 'nej';
         }
-    }
-
-    function shouldShowStickySummary() {
-        return (
-            document.body.dataset.resultsReady === 'true' &&
-            currentIndex === idx.summary
-        );
-    }
-
-    function updateStickyCtaLabel() {
-        if (!stickyCTA) return;
-        const resultsReady = document.body.dataset.resultsReady === 'true';
-        stickyCTA.textContent = resultsReady ? 'Optimera' : 'Visa resultat';
-        if (mobileSummary) {
-            mobileSummary.classList.toggle('is-visible', shouldShowStickySummary());
-        }
-    }
-
-    function updateNavigation() {
-        backBtn.classList.toggle('hidden', currentIndex === idx.household);
-        const onSummary = currentIndex === idx.summary;
-        nextBtn.classList.toggle('hidden', onSummary);
-        calculateBtn.classList.toggle('hidden', !onSummary);
-        nextBtn.textContent = currentIndex === idx.preferences ? 'Gå till resultat' : 'Nästa steg';
-        updateStickyCtaLabel();
-    }
-
-    function displayStep(index, recordHistory = false) {
-        if (index < 0 || index >= steps.length) return;
-        if (recordHistory) {
-            history.push(currentIndex);
-        }
-        steps.forEach((step, i) => step.classList.toggle('visible', i === index));
-        currentIndex = index;
-        updateProgress(index + 1);
-        updateNavigation();
-        if (hasDisplayedInitially) {
-            scrollToWizardTop();
-        } else {
-            hasDisplayedInitially = true;
-        }
-    }
-
-    function validateStep(index) {
-        if (index === idx.household) {
-            const custodyInput = document.getElementById('vårdnad');
-            const custodyValue = custodyInput ? custodyInput.value : '';
-            const info = document.getElementById('vårdnad-info');
-            if (!custodyValue) {
-                if (info) info.textContent = 'Välj vårdnadstyp för att fortsätta.';
-                return false;
-            }
-            if (info && info.textContent) info.textContent = '';
-            const plannedValue = Number.parseInt(document.getElementById('barn-planerade').value, 10);
-            const validPlanned = Number.isFinite(plannedValue) && plannedValue > 0;
-            if (barnError) {
-                barnError.style.display = validPlanned ? 'none' : 'block';
-            }
-            return validPlanned;
-        }
-        if (index === idx.income) {
-            const income1 = document.getElementById('inkomst1');
-            if (income1 && (!income1.value || Number(income1.value) <= 0)) {
-                income1.focus();
-                if (typeof income1.reportValidity === 'function') {
-                    income1.reportValidity();
+        if (!visible) {
+            partnerInputs.forEach(input => {
+                if (input instanceof HTMLInputElement) {
+                    input.value = '';
                 }
-                return false;
+            });
+            const avtalButtons = document.querySelectorAll('#avtal-group-2 .toggle-btn');
+            avtalButtons.forEach(button => button.classList.remove('active'));
+            const avtalInput = document.getElementById('har-avtal-2');
+            if (avtalInput) {
+                avtalInput.value = '';
+            }
+            if (employmentContainer2) {
+                employmentContainer2.style.display = 'none';
             }
         }
-        return true;
     }
 
-    backBtn.addEventListener('click', () => {
-        if (history.length === 0) return;
-        const previous = history.pop();
-        displayStep(previous, false);
-    });
-
-    nextBtn.addEventListener('click', () => {
-        if (!validateStep(currentIndex)) return;
-        const nextIndex = Math.min(currentIndex + 1, steps.length - 1);
-        displayStep(nextIndex, true);
-    });
+    if (partnerCheckbox) {
+        partnerCheckbox.addEventListener('change', () => {
+            setPartnerFieldsVisible(partnerCheckbox.checked);
+            document.body.dataset.resultsReady = 'false';
+            window.appState = undefined;
+            document.dispatchEvent(new Event('results-reset'));
+        });
+    }
 
     if (stickyCTA) {
         stickyCTA.addEventListener('click', () => {
             if (document.body.dataset.resultsReady === 'true') {
-                document.getElementById('optimize-btn')?.click();
-                return;
-            }
-            if (currentIndex !== idx.summary) {
-                nextBtn.click();
-            } else if (!calculateBtn.classList.contains('hidden')) {
-                calculateBtn.click();
-            }
-        });
-    }
-
-    progressSteps.forEach((stepEl, index) => {
-        stepEl.addEventListener('click', () => {
-            if (index > currentIndex) return;
-            displayStep(index, true);
-        });
-    });
-
-    document.addEventListener('results-ready', updateStickyCtaLabel);
-    document.addEventListener('results-reset', updateStickyCtaLabel);
-
-    setPartnerFieldsVisible(true);
-    displayStep(idx.household);
-    handleScroll();
-
-    setupToggleButtons('vårdnad-group', 'vårdnad', value => {
-        const isEnsam = value === 'ensam';
-        if (partnerCheckbox) {
-            partnerCheckbox.disabled = isEnsam;
-            if (isEnsam) {
-                partnerCheckbox.checked = false;
-                setPartnerFieldsVisible(false);
+                optimizeButton?.click();
             } else {
-                setPartnerFieldsVisible(partnerCheckbox.checked);
+                if (form && typeof form.requestSubmit === 'function') {
+                    form.requestSubmit();
+                } else {
+                    form?.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+                }
             }
-        } else if (isEnsam) {
-            setPartnerFieldsVisible(false);
-        }
-    });
-
-    if (partnerCheckbox) {
-        partnerCheckbox.addEventListener('change', () => {
-            if (partnerCheckbox.disabled) return;
-            setPartnerFieldsVisible(partnerCheckbox.checked);
         });
     }
-
-    setupToggleButtons('barn-tidigare-group', 'barn-tidigare', () => {
-        if (barnError) barnError.style.display = 'none';
-    });
-    setupToggleButtons('barn-planerade-group', 'barn-planerade', () => {
-        if (barnError) barnError.style.display = 'none';
-    });
 
     setupToggleButtons('avtal-group-1', 'har-avtal-1', value => {
         const container = document.getElementById('anstallningstid-container-1');
@@ -227,12 +82,11 @@ document.addEventListener('DOMContentLoaded', () => {
     setupToggleButtons('anstallningstid-group-1', 'anstallningstid-1');
 
     setupToggleButtons('avtal-group-2', 'har-avtal-2', value => {
-        const container = document.getElementById('anstallningstid-container-2');
-        if (!container) return;
+        if (!employmentContainer2) return;
         if (value === 'ja' && partnerActive) {
-            container.style.display = 'block';
+            employmentContainer2.style.display = 'block';
         } else {
-            container.style.display = 'none';
+            employmentContainer2.style.display = 'none';
             const input = document.getElementById('anstallningstid-2');
             if (input) input.value = '';
         }
@@ -240,255 +94,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
     setupToggleButtons('anstallningstid-group-2', 'anstallningstid-2');
 
-    const toggleInputMap = {
-        'vårdnad-group': 'vårdnad',
-        'barn-tidigare-group': 'barn-tidigare',
-        'barn-planerade-group': 'barn-planerade',
-        'avtal-group-1': 'har-avtal-1',
-        'avtal-group-2': 'har-avtal-2',
-        'anstallningstid-group-1': 'anstallningstid-1',
-        'anstallningstid-group-2': 'anstallningstid-2'
-    };
-
-    function applyToggleValue(groupId, value) {
-        const groupEl = document.getElementById(groupId);
-        if (!groupEl) return;
-        const inputId = toggleInputMap[groupId];
-        const inputEl = inputId ? document.getElementById(inputId) : null;
-        const buttons = groupEl.querySelectorAll('.toggle-btn');
-        buttons.forEach(button => {
-            const isActive = button.dataset.value === value;
-            button.classList.toggle('active', isActive);
-            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
-        if (inputEl) {
-            inputEl.value = value ?? '';
-        }
-        if (groupId === 'barn-tidigare-group') {
-            window.barnIdag = Number.parseInt(value ?? '0', 10);
-        }
-        if (groupId === 'barn-planerade-group') {
-            window.barnPlanerat = Number.parseInt(value ?? '0', 10);
-        }
-    }
-
-    function resetFormState() {
-        Object.keys(toggleInputMap).forEach(groupId => applyToggleValue(groupId, null));
-
-        const inputsToClear = [
-            'inkomst1',
-            'inkomst2',
-            'ledig-tid-5823',
-            'ledig-tid-2',
-            'min-inkomst'
-        ];
-        inputsToClear.forEach(id => {
-            const input = document.getElementById(id);
-            if (input) input.value = '';
-        });
-
-        const birthDateInput = document.getElementById('barn-datum');
-        if (birthDateInput) birthDateInput.value = '';
-
-        const strategyInput = document.getElementById('strategy');
-        const strategyButtons = document.querySelectorAll('#strategy-group .toggle-btn');
-        strategyButtons.forEach((button, index) => {
-            const isDefault = index === 0;
-            button.classList.toggle('active', isDefault);
-            button.setAttribute('aria-pressed', isDefault ? 'true' : 'false');
-        });
-        if (strategyInput) strategyInput.value = 'longer';
-
-        const container1 = document.getElementById('anstallningstid-container-1');
-        if (container1) container1.style.display = 'none';
-        const container2 = document.getElementById('anstallningstid-container-2');
-        if (container2) container2.style.display = 'none';
-
-        const slider = document.getElementById('leave-slider');
-        if (slider) {
-            slider.value = 0;
-            slider.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-        const leaveContainer = document.getElementById('leave-slider-container');
-        if (leaveContainer) leaveContainer.style.display = 'none';
-
-        if (partnerCheckbox) {
-            partnerCheckbox.disabled = false;
-            partnerCheckbox.checked = true;
-        }
-        setPartnerFieldsVisible(true);
-        document.body.dataset.resultsReady = 'false';
-        window.appState = undefined;
-        document.dispatchEvent(new Event('results-reset'));
-        history = [];
-        hasDisplayedInitially = false;
-        displayStep(idx.household);
-    }
-
-    function employmentOptionForParent(parent) {
-        if (!parent) return null;
-        if (typeof parent.anstalld_mer_an_ett_ar === 'boolean') {
-            return parent.anstalld_mer_an_ett_ar ? '>1' : '6-12';
-        }
-        if (typeof parent.anstalld_manader === 'number') {
-            if (parent.anstalld_manader <= 5) return '0-5';
-            if (parent.anstalld_manader <= 12) return '6-12';
-            return '>1';
-        }
-        return null;
-    }
-
-    function populateFamilyData(family) {
-        if (!family) return;
-        resetFormState();
-        const custodyType = (family.custody?.typ || '').toString().toLowerCase().trim();
-        const isGemensam = /\bgemensam\b/.test(custodyType);
-        const isEnsam = /\bensam\b/.test(custodyType);
-        const custodyValue = isEnsam && !isGemensam ? 'ensam' : 'gemensam';
-        applyToggleValue('vårdnad-group', custodyValue);
-
-        const partnerPref = family.custody?.berakna_for_bada_foraldrarna;
-        const partnerFallback = family.custody?.berakna_for_partner;
-        const shouldIncludePartner = typeof partnerPref === 'boolean'
-            ? partnerPref
-            : (typeof partnerFallback === 'boolean' ? partnerFallback : true);
-        const parents = Array.isArray(family.parents) ? family.parents : [];
-        const hasSecondParent = parents.length > 1;
-        const includePartner = custodyValue === 'gemensam' && shouldIncludePartner && hasSecondParent;
-
-        if (partnerCheckbox) {
-            partnerCheckbox.disabled = custodyValue === 'ensam';
-            partnerCheckbox.checked = includePartner;
-        }
-        setPartnerFieldsVisible(includePartner);
-
-        const existingChildren = family.barn?.befintliga ?? 0;
-        applyToggleValue('barn-tidigare-group', existingChildren.toString());
-        const plannedChildren = family.barn?.forvantade ?? 0;
-        applyToggleValue('barn-planerade-group', plannedChildren.toString());
-
-        const parent1 = parents[0] || {};
-        const parent2 = includePartner ? parents[1] || {} : null;
-
-        const preferences = family.preferenser || {};
-        const parseMonths = value => {
-            const parsed = Number(value);
-            return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
-        };
-        const normalizedStrategy = (() => {
-            const raw = (preferences.strategi || '').toString().toLowerCase();
-            if (raw === 'maximize' || raw === 'maximize_parental_salary') return 'maximize';
-            return 'longer';
-        })();
-
-        const income1Input = document.getElementById('inkomst1');
-        const income2Input = document.getElementById('inkomst2');
-        if (income1Input) income1Input.value = parent1.salary_sek_per_month ?? '';
-        if (income2Input) income2Input.value = parent2?.salary_sek_per_month ?? '';
-
-        const minIncomeInput = document.getElementById('min-inkomst');
-        if (minIncomeInput) {
-            const minIncome = preferences.minimi_netto_sek_per_manad ?? family.miniminkomst_sek_per_manad;
-            minIncomeInput.value = (minIncome ?? '').toString();
-        }
-
-        const avtal1Value = parent1.kollektivavtal ? 'ja' : 'nej';
-        applyToggleValue('avtal-group-1', avtal1Value);
-        const employment1 = employmentOptionForParent(parent1);
-        const container1 = document.getElementById('anstallningstid-container-1');
-        if (container1) {
-            if (avtal1Value === 'ja' && employment1) {
-                container1.style.display = 'block';
-                applyToggleValue('anstallningstid-group-1', employment1);
-            } else {
-                container1.style.display = 'none';
-                applyToggleValue('anstallningstid-group-1', null);
-            }
-        }
-
-        const avtal2Value = parent2?.kollektivavtal ? 'ja' : 'nej';
-        applyToggleValue('avtal-group-2', includePartner ? avtal2Value : null);
-        const container2 = document.getElementById('anstallningstid-container-2');
-        const employment2 = employmentOptionForParent(parent2);
-        if (container2) {
-            if (includePartner && avtal2Value === 'ja' && employment2) {
-                container2.style.display = 'block';
-                applyToggleValue('anstallningstid-group-2', employment2);
-            } else {
-                container2.style.display = 'none';
-                applyToggleValue('anstallningstid-group-2', null);
-            }
-        }
-
-        const birthDateInput = document.getElementById('barn-datum');
-        if (birthDateInput) {
-            if (preferences.beraknat_fodelsedatum) {
-                birthDateInput.value = preferences.beraknat_fodelsedatum;
-            } else {
-                const today = new Date();
-                const local = new Date(today.getTime() - today.getTimezoneOffset() * 60000);
-                birthDateInput.value = local.toISOString().split('T')[0];
-            }
-        }
-
-        const totalLeaveInput = document.getElementById('ledig-tid-5823');
-        const partnerLeaveInput = document.getElementById('ledig-tid-2');
-        const parentMonths = parseMonths(preferences.foralder1_manader);
-        const partnerMonths = parseMonths(preferences.foralder2_manader);
-        if (totalLeaveInput && parentMonths !== null) {
-            totalLeaveInput.value = parentMonths;
-        }
-        if (partnerLeaveInput) {
-            if (includePartner && partnerMonths !== null) {
-                partnerLeaveInput.value = partnerMonths;
-            } else {
-                partnerLeaveInput.value = '';
-            }
-        }
-
-        const strategyInput = document.getElementById('strategy');
-        const strategyButtons = document.querySelectorAll('#strategy-group .toggle-btn');
-        strategyButtons.forEach(button => {
-            const isActive = button.dataset.value === normalizedStrategy;
-            button.classList.toggle('active', isActive);
-            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        });
-        if (strategyInput) strategyInput.value = normalizedStrategy;
-
-        totalLeaveInput?.dispatchEvent(new Event('input', { bubbles: true }));
-        partnerLeaveInput?.dispatchEvent(new Event('input', { bubbles: true }));
-
-        history = [idx.household, idx.income, idx.preferences];
-        displayStep(idx.summary, false);
-    }
-
-    const devFamilyButtons = document.querySelectorAll('.dev-family-btn');
-    let familiesRequest;
-
-    function fetchFamilies() {
-        if (!familiesRequest) {
-            familiesRequest = fetch('/dev/families', { cache: 'no-store' })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`Failed to load families: ${response.status}`);
-                    }
-                    return response.json();
-                })
-                .catch(error => {
-                    console.error(error);
-                    return [];
-                });
-        }
-        return familiesRequest;
-    }
-
-    devFamilyButtons.forEach(button => {
-        button.addEventListener('click', () => {
-            const index = Number.parseInt(button.dataset.familyIndex, 10);
-            fetchFamilies().then(families => {
-                if (!Array.isArray(families) || !families[index]) return;
-                populateFamilyData(families[index]);
-            });
-        });
-    });
+    setPartnerFieldsVisible(partnerActive);
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,94 +13,12 @@
 </head>
 <body>
     <div class="container">
-        <div id="progress-bar">
-            <div class="step step-1 active">
-                <div class="step-circle"><i class="fa-solid fa-house-chimney"></i></div>
-                <span class="step-label">Hushåll &amp; barn</span>
-            </div>
-            <div class="step step-2">
-                <div class="step-circle"><i class="fa-solid fa-coins"></i></div>
-                <span class="step-label">Inkomster &amp; avtal</span>
-            </div>
-            <div class="step step-3">
-                <div class="step-circle"><i class="fa-solid fa-sliders"></i></div>
-                <span class="step-label">Preferenser</span>
-            </div>
-            <div class="step step-4">
-                <div class="step-circle"><i class="fa-solid fa-chart-line"></i></div>
-                <span class="step-label">Resultat</span>
-            </div>
-        </div>
-        
         <h1>Föräldrapenningkalkylator</h1>
         
         <form id="calc-form">
-            <fieldset class="wizard-step visible" id="step-household">
-                <legend>Hushåll &amp; barn</legend>
-                <div class="wizard-first-step-layout">
-                    <div class="dev-shortcuts" aria-hidden="true">
-                        <button type="button" class="dev-family-btn" data-family-index="0" data-short-label="1" aria-label="2 parents, 3 kids, medium income"><span class="family-label-text">2 parents, 3 kids, medium income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="1" data-short-label="2" aria-label="1 parent, 2 kids, high income"><span class="family-label-text">1 parent, 2 kids, high income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="2" data-short-label="3" aria-label="2 parents, 2 kids, high income"><span class="family-label-text">2 parents, 2 kids, high income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="3" data-short-label="4" aria-label="2 parents, 3 kids, single-income plan"><span class="family-label-text">2 parents, 3 kids, single-income plan</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="4" data-short-label="5" aria-label="2 parents, 1 kid, low income"><span class="family-label-text">2 parents, 1 kid, low income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="5" data-short-label="6" aria-label="2 parents, 4 kids, medium income"><span class="family-label-text">2 parents, 4 kids, medium income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="6" data-short-label="7" aria-label="1 parent, 3 kids, high income"><span class="family-label-text">1 parent, 3 kids, high income</span></button>
-                        <button type="button" class="dev-family-btn" data-family-index="7" data-short-label="8" aria-label="2 parents, twins on the way, mixed income"><span class="family-label-text">2 parents, twins on the way, mixed income</span></button>
-                    </div>
-                    <div class="wizard-first-step-content">
-                        <div class="form-section">
-                            <div class="question-icon"><i class="fa-solid fa-people-roof"></i></div>
-                            <label for="vårdnad">Har du Gemensam eller Ensam vårdnad?</label>
-                            <div class="button-group" id="vårdnad-group">
-                                <button type="button" class="vårdnad-btn toggle-btn" data-value="gemensam">Gemensam</button>
-                                <button type="button" class="vårdnad-btn toggle-btn" data-value="ensam">Ensam</button>
-                            </div>
-                            <input type="hidden" name="vårdnad" id="vårdnad" value="">
-                            <p id="vårdnad-info" class="info-text"></p>
-                        </div>
-                        <div class="form-section">
-                            <div class="question-icon"><i class="fa-solid fa-user-plus"></i></div>
-                            <label for="beräkna-partner-checkbox" class="checkbox-label">
-                                <input type="checkbox" id="beräkna-partner-checkbox" checked>
-                                Beräkna föräldrapenning för partner
-                            </label>
-                            <input type="hidden" name="beräkna_partner" id="beräkna-partner" value="ja">
-                        </div>
-                        <div class="form-section">
-                            <div class="question-icon"><i class="fa-solid fa-children"></i></div>
-                            <label>Hur många barn har du/ni sedan tidigare?</label>
-                            <div class="button-group barnval" id="barn-tidigare-group">
-                                <button type="button" class="toggle-btn" data-value="0">0</button>
-                                <button type="button" class="toggle-btn" data-value="1">1</button>
-                                <button type="button" class="toggle-btn" data-value="2">2</button>
-                                <button type="button" class="toggle-btn" data-value="3">3</button>
-                                <button type="button" class="toggle-btn" data-value="4">4</button>
-                                <button type="button" class="toggle-btn" data-value="5">5</button>
-                            </div>
-                            <input type="hidden" id="barn-tidigare" value="0">
-                        </div>
-                        <div class="form-section">
-                            <div class="question-icon"><i class="fa-solid fa-baby-carriage"></i></div>
-                            <label>Hur många fler barn planerar du/ni att få?</label>
-                            <div class="button-group barnval" id="barn-planerade-group">
-                                <button type="button" class="toggle-btn" data-value="1">1</button>
-                                <button type="button" class="toggle-btn" data-value="2">2</button>
-                                <button type="button" class="toggle-btn" data-value="3">3</button>
-                                <button type="button" class="toggle-btn" data-value="4">4</button>
-                                <button type="button" class="toggle-btn" data-value="5">5</button>
-                                <button type="button" class="toggle-btn" data-value="6">6</button>
-                            </div>
-                            <input type="hidden" id="barn-planerade" value="0">
-                        </div>
-                    </div>
-                </div>
-                <div id="barn-selection-error" class="inline-error" role="alert" aria-live="assertive" style="display: none;">
-                    Vänligen välj både antal barn idag och antal planerade barn.
-                </div>
-            </fieldset>
 
             <fieldset class="wizard-step" id="step-income">
+                <input type="hidden" name="vårdnad" id="vårdnad" value="gemensam">
                 <legend>Inkomster &amp; avtal</legend>
                 <div class="form-section" id="inkomst-avtal-1">
                     <div class="question-icon"><i class="fa-solid fa-sack-dollar"></i></div>
@@ -144,6 +62,15 @@
                         </div>
                         <input type="hidden" name="anstallningstid_1" id="anstallningstid-1" value="">
                     </div>
+                </div>
+
+                <div class="form-section">
+                    <div class="question-icon"><i class="fa-solid fa-user-plus"></i></div>
+                    <label for="beräkna-partner-checkbox" class="checkbox-label">
+                        <input type="checkbox" id="beräkna-partner-checkbox" checked>
+                        Beräkna föräldrapenning för partner
+                    </label>
+                    <input type="hidden" name="beräkna_partner" id="beräkna-partner" value="ja">
                 </div>
 
                 <div id="inkomst-block-2" class="form-section" data-partner-field>
@@ -191,69 +118,33 @@
                 </div>
             </fieldset>
 
-            <fieldset class="wizard-step" id="step-preferences">
-                <legend>Preferenser</legend>
-                <div class="form-section">
-                    <label>När är barnet beräknat?</label>
-                    <div class="date-picker-container">
-                        <input type="date" id="barn-datum" name="barn-datum" required>
-                    </div>
+            <div class="form-section">
+                <label for="min-inkomst">Minimi-netto för hushållet (kr/månad)</label>
+                <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
+                <div id="min-income-error" class="inline-error" role="alert" aria-live="assertive" style="display: none;"></div>
+            </div>
+            <div class="info-box open household-income-info">
+                <div class="info-header">
+                    <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
+                    <span><strong>Riktvärden för hushållets netto</strong></span>
+                    <span class="info-arrow">▾</span>
                 </div>
-                <div class="form-section">
-                    <label>Hur länge vill du/ni vara lediga? (månader)</label>
-                    <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
+                <div class="info-content">
+                    <p>
+                        Använd riktvärdena nedan om du är osäker på vilket minimi-netto ditt hushåll behöver varje månad.
+                    </p>
+                    <ul>
+                        <li><strong>Ensam förälder:</strong> cirka 22&nbsp;000 kr/månad</li>
+                        <li><strong>Två vuxna hushåll:</strong> cirka 32&nbsp;000 kr/månad</li>
+                    </ul>
+                    <p class="info-note">
+                        Riktvärdena baseras på genomsnittliga hushållsbudgetar från Konsumentverket (2024) och kan justeras efter era egna kostnader.
+                    </p>
                 </div>
-                <div class="form-section" id="parent-ledig-tid" data-partner-field>
-                    <label>Hur länge vill din partner vara ledig? (månader)</label>
-                    <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
-                </div>
-                <div class="form-section">
-                    <label for="min-inkomst">Minimi-netto för hushållet (kr/månad)</label>
-                    <input type="number" id="min-inkomst" name="min-inkomst" min="0" placeholder="Ange belopp">
-                    <div id="min-income-error" class="inline-error" role="alert" aria-live="assertive" style="display: none;"></div>
-                </div>
-                <div class="info-box open household-income-info">
-                    <div class="info-header">
-                        <span class="info-icon"><i class="fa-solid fa-circle-info"></i></span>
-                        <span><strong>Riktvärden för hushållets netto</strong></span>
-                        <span class="info-arrow">▾</span>
-                    </div>
-                    <div class="info-content">
-                        <p>
-                            Använd riktvärdena nedan om du är osäker på vilket minimi-netto ditt hushåll behöver varje månad.
-                        </p>
-                        <ul>
-                            <li><strong>Ensam förälder med 1 barn:</strong> cirka 22&nbsp;000 kr/månad</li>
-                            <li><strong>Två föräldrar med 2 barn:</strong> cirka 32&nbsp;000 kr/månad</li>
-                            <li><strong>Två föräldrar med 3 barn:</strong> cirka 45&nbsp;000 kr/månad</li>
-                        </ul>
-                        <p class="info-note">
-                            Riktvärdena baseras på genomsnittliga hushållsbudgetar från Konsumentverket (2024) och kan justeras efter era egna kostnader.
-                        </p>
-                    </div>
-                </div>
-                <div class="form-section">
-                    <label for="strategy">Välj strategi:</label>
-                    <div class="toggle-group" id="strategy-group">
-                        <div class="strategy-spacer" aria-hidden="true"></div>
-                        <div class="toggle-options">
-                            <button type="button" class="toggle-btn active" data-value="longer">Längre ledighet</button>
-                            <button type="button" class="toggle-btn" data-value="maximize">Maximera inkomst</button>
-                        </div>
-                        <input type="hidden" id="strategy" value="longer">
-                    </div>
-                </div>
-            </fieldset>
+            </div>
 
-            <fieldset class="wizard-step" id="step-summary">
-                <legend>Resultat</legend>
-                <p class="summary-intro">Sammanfatta dina uppgifter och visa resultatet när du är redo.</p>
-            </fieldset>
-
-            <div class="wizard-nav">
-                <button type="button" id="back-btn" class="hidden back-btn">&larr; Tillbaka</button>
-                <button type="button" id="next-btn">Nästa steg</button>
-                <button type="submit" id="calculate-btn" class="hidden">Visa resultat</button>
+            <div class="form-actions">
+                <button type="submit" id="calculate-btn" class="primary-cta">Beräkna</button>
             </div>
         </form>
 
@@ -268,10 +159,31 @@
                     <span class="summary-value" id="sticky-days">–</span>
                 </div>
             </div>
-            <button type="button" id="sticky-cta" class="primary-cta">Visa resultat</button>
+            <button type="button" id="sticky-cta" class="primary-cta">Beräkna</button>
         </div>
 
         <div id="result-block"></div>
+        <section id="results-controls" aria-label="Resultatinställningar">
+            <div class="form-section">
+                <label>Hur länge vill du vara ledig? (månader)</label>
+                <input type="number" id="ledig-tid-5823" name="ledig-tid-1" min="0" placeholder="Ange antal månader">
+            </div>
+            <div class="form-section" id="parent-ledig-tid" data-partner-field>
+                <label>Hur länge vill din partner vara ledig? (månader)</label>
+                <input type="number" id="ledig-tid-2" name="ledig-tid-2" min="0" placeholder="Ange antal månader">
+            </div>
+            <div class="form-section">
+                <label for="strategy">Välj strategi:</label>
+                <div class="toggle-group" id="strategy-group">
+                    <div class="strategy-spacer" aria-hidden="true"></div>
+                    <div class="toggle-options">
+                        <button type="button" class="toggle-btn active" data-value="longer">Längre ledighet</button>
+                        <button type="button" class="toggle-btn" data-value="maximize">Maximera inkomst</button>
+                    </div>
+                    <input type="hidden" id="strategy" value="longer">
+                </div>
+            </div>
+        </section>
         <div class="preference-group" id="leave-slider-container" style="display: none;">
             <input type="range" id="leave-slider" min="0" max="0" value="0" step="1" list="leave-ticks">
             <datalist id="leave-ticks"></datalist>
@@ -281,7 +193,7 @@
             </div>
             <div class="slider-values">
                 <span class="slider-value p1-value"><strong>Förälder 1:</strong> <span id="p1-months">0</span> månader</span>
-                <span class="slider-value p2-value"><strong>Förälder 2:</strong> <span id="p2-months">0</span> månader</span>
+                <span class="slider-value p2-value" data-partner-field><strong>Förälder 2:</strong> <span id="p2-months">0</span> månader</span>
             </div>
             <div class="slider-min-income">
                 <label for="min-inkomst-result">Minimi-netto för hushållet (kr/månad)</label>


### PR DESCRIPTION
## Summary
- restructure the calculator page into a single-step form with the partner toggle, income inputs, and minimum household income captured up front while leaving leave distribution and strategy controls in the results area
- align the client-side logic with the new layout, removing child allowance dependencies, resetting results when inputs change, and updating the sticky action to run calculations or optimizations appropriately
- simplify configuration and helper scripts by zeroing child allowance defaults and focusing the wizard script on partner visibility management

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e751f318c8832b836f738628895a81