### PR TITLE
Refine monthly results and drop child allowances

### DIFF
--- a/static/calculations.js
+++ b/static/calculations.js
@@ -243,7 +243,9 @@ function applyMinimumLevelDayUsage(options) {
 export function beräknaMånadsinkomst(dag, dagarPerVecka, extra, barnbidrag = DEFAULT_BARNBIDRAG, tillägg = 0) {
     const fp = Math.round((dag * dagarPerVecka * 4.3) / 100) * 100;
     const extraBelopp = extra ? Math.round(extra * (dagarPerVecka / 7)) : 0;
-    const resultat = beräknaNetto(fp) + beräknaNetto(extraBelopp) + barnbidrag + tillägg;
+    const resultat = beräknaNetto(fp) + beräknaNetto(extraBelopp);
+    void barnbidrag;
+    void tillägg;
     return resultat || 0;
 }
 
@@ -302,17 +304,13 @@ export function beräknaNetto(inkomst, skattesats = 30) {
  * @returns {Object} Object with barnbidrag, tillägg, total, and details
  */
 export function beräknaBarnbidrag(totalBarn, ensamVårdnad) {
-    const bidragPerBarn = 1250;
-    const flerbarnstillägg = { 2: 150, 3: 730, 4: 1740, 5: 2990, 6: 4240 };
-    const barnbidrag = bidragPerBarn * totalBarn;
-    const tillägg = flerbarnstillägg[totalBarn] || 0;
-    const total = barnbidrag + tillägg;
-    const details = `${totalBarn} barn ger ${barnbidrag.toLocaleString()} kr barnbidrag${tillägg ? " + " + tillägg + " kr flerbarnstillägg" : ""} = <strong>${total.toLocaleString()} kr</strong>`;
+    void totalBarn;
+    void ensamVårdnad;
     return {
-        barnbidrag: ensamVårdnad ? barnbidrag : Math.round(barnbidrag / 2),
-        tillägg: ensamVårdnad ? tillägg : Math.round(tillägg / 2),
-        total: ensamVårdnad ? total : Math.round(total / 2),
-        details
+        barnbidrag: 0,
+        tillägg: 0,
+        total: 0,
+        details: ''
     };
 }
 
@@ -374,8 +372,8 @@ function optimizeParentalLeaveLegacy(preferences, inputs) {
         return severity;
     };
 
-    const barnbidrag = inputs.barnbidragPerPerson || 1250;
-    const tillägg = inputs.tilläggPerPerson || 75;
+    const barnbidrag = 0;
+    const tillägg = 0;
 
     const inkomst1 = Number(inputs.inkomst1) || 0;
     const inkomst2 = Number(inputs.inkomst2) || 0;
@@ -412,8 +410,8 @@ function optimizeParentalLeaveLegacy(preferences, inputs) {
     let användaMinDagar1 = 0;
     let användaMinDagar2 = 0;
 
-    const arbetsInkomst1 = beräknaNetto(inkomst1) + barnbidrag + tillägg;
-    const arbetsInkomst2 = inkomst2 > 0 ? beräknaNetto(inkomst2) + barnbidrag + tillägg : 0;
+    const arbetsInkomst1 = beräknaNetto(inkomst1);
+    const arbetsInkomst2 = inkomst2 > 0 ? beräknaNetto(inkomst2) : 0;
 
     let dagarPerVecka1 = 0;
     let dagarPerVecka1NoExtra = 0;
@@ -1160,8 +1158,8 @@ function optimizeParentalLeaveParentalSalary(preferences, inputs) {
         return severity;
     };
 
-    const barnbidrag = inputs.barnbidragPerPerson || 1250;
-    const tillägg = inputs.tilläggPerPerson || 75;
+    const barnbidrag = 0;
+    const tillägg = 0;
 
     const inkomst1 = Number(inputs.inkomst1) || 0;
     const inkomst2 = Number(inputs.inkomst2) || 0;
@@ -1198,8 +1196,8 @@ function optimizeParentalLeaveParentalSalary(preferences, inputs) {
     let användaMinDagar1 = 0;
     let användaMinDagar2 = 0;
 
-    const arbetsInkomst1 = beräknaNetto(inkomst1) + barnbidrag + tillägg;
-    const arbetsInkomst2 = inkomst2 > 0 ? beräknaNetto(inkomst2) + barnbidrag + tillägg : 0;
+    const arbetsInkomst1 = beräknaNetto(inkomst1);
+    const arbetsInkomst2 = inkomst2 > 0 ? beräknaNetto(inkomst2) : 0;
 
     let dagarPerVecka1 = 0;
     let dagarPerVecka1NoExtra = 0;

--- a/static/style.css
+++ b/static/style.css
@@ -500,6 +500,119 @@ input[type="number"] {
     text-align: center;
 }
 
+#result-block .result-section {
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    margin-bottom: 2rem;
+}
+
+#result-block .result-section > :not(.monthly-card) {
+    display: none !important;
+}
+
+#result-block .monthly-wrapper {
+    margin-top: 0;
+}
+
+.monthly-card {
+    background: #ffffff;
+    border: 1px solid #d0d5dd;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.monthly-card-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.monthly-box-title {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.income-summary {
+    flex: 0 0 auto;
+    width: min(240px, 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 12px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    max-width: 240px;
+    box-sizing: border-box;
+    align-self: flex-start;
+}
+
+.income-summary-label {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0;
+    color: #1f2937;
+}
+
+.income-summary-value {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    color: #00796b;
+}
+
+.monthly-side-column {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+}
+
+.feasibility-message {
+    position: relative;
+}
+
+.feasibility-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    cursor: pointer;
+    text-align: left;
+}
+
+.feasibility-toggle:focus-visible {
+    outline: 2px solid #00796b;
+    outline-offset: 2px;
+}
+
+.feasibility-message .feasibility-content {
+    margin-top: 1rem;
+}
+
+.feasibility-message.collapsed .feasibility-content[hidden] {
+    display: none;
+}
+
+.feasibility-toggle-icon {
+    transition: transform 0.2s ease-in-out;
+}
+
+.feasibility-message.expanded .feasibility-toggle-icon {
+    transform: rotate(180deg);
+}
+
 .result-section {
     margin-bottom: 2rem;
     background: #dbdbdb;
@@ -847,6 +960,7 @@ input[type="number"] {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: 20px;
     margin-top: 20px;
 }
@@ -1061,7 +1175,7 @@ input[type="number"] {
         font-size: 0.9rem;
     }
 
-    .monthly-box h3,
+    .monthly-box-title,
     .benefit-title {
         font-size: 1rem;
     }
@@ -2572,11 +2686,14 @@ canvas#gantt-canvas {
     }
 
     .monthly-box,
-    .uttag-container {
+    .income-summary,
+    .uttag-container,
+    .monthly-side-column {
         width: 100%;
         max-width: 100%;
     }
 
+    .income-summary,
     .uttag-container {
         align-items: center;
         text-align: center;
@@ -2604,7 +2721,7 @@ canvas#gantt-canvas {
     .result-section,
     .result-section h2,
     .result-section h4,
-    .monthly-box h3,
+    .monthly-box-title,
     .benefit-title,
     .strategy-days-heading {
         text-align: center;


### PR DESCRIPTION
## Summary
- wrap the monthly result content in a bordered card with a clear parent heading and add a stacked income summary above the withdrawal selector
- restyle the feasibility toggle to reuse the existing strategy toggle appearance and adapt styling for the new layout
- remove barnbidrag and flerbarnstillägg from UI totals, calculations, and chart summaries so they no longer influence incomes

## Testing
- not run (front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68e7660c3974832b8e52065f69366de1