### PR TITLE
Add side-panel Chrome extension to extract and export event attendees

### DIFF
--- a/event-attendee-extension/README.md
+++ b/event-attendee-extension/README.md
@@ -1,0 +1,29 @@
+# Event Attendee Extractor (Chrome Extension)
+
+## What it does
+
+- Extracts attendees from the current event page.
+- Shows attendee name and title in the side panel.
+- Lets you expand each attendee to view contact data if present.
+- Supports local save, CSV export, and PDF export.
+
+## Install (developer mode)
+
+1. Open Chrome and go to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked**.
+4. Select the `event-attendee-extension` folder.
+
+## Usage
+
+1. Open an event attendee page.
+2. Click the extension icon to open the side panel.
+3. Click **Extract attendees**.
+4. Expand any attendee card to view contact details.
+5. Use **Save locally**, **Export CSV**, or **Export PDF**.
+
+## Notes
+
+- Extraction depends on the current event page DOM.
+- If contact details are not visible in the page, they cannot be extracted.
+- Debug logs are available in the page console and extension console.

--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -1,0 +1,76 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log("[Event Attendee Extractor] Extension installed.");
+});
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id) {
+    return;
+  }
+
+  await chrome.sidePanel.open({ tabId: tab.id });
+  console.log("[Event Attendee Extractor] Side panel opened.");
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "SCRAPE_ATTENDEES") {
+    scrapeFromActiveTab(sendResponse);
+    return true;
+  }
+
+  if (message?.type === "GET_LAST_ATTENDEES") {
+    chrome.storage.local.get(["lastAttendees", "lastScrapedAt"], (result) => {
+      sendResponse({
+        attendees: result.lastAttendees ?? [],
+        lastScrapedAt: result.lastScrapedAt ?? null
+      });
+    });
+    return true;
+  }
+
+  return false;
+});
+
+async function scrapeFromActiveTab(sendResponse) {
+  try {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true
+    });
+
+    if (!tab?.id) {
+      sendResponse({ ok: false, error: "No active tab found." });
+      return;
+    }
+
+    const response = await chrome.tabs.sendMessage(tab.id, {
+      type: "EXTRACT_ATTENDEES"
+    });
+
+    if (!response?.ok) {
+      sendResponse({
+        ok: false,
+        error: response?.error ?? "Content script did not return data."
+      });
+      return;
+    }
+
+    const payload = {
+      lastAttendees: response.attendees,
+      lastScrapedAt: new Date().toISOString()
+    };
+
+    chrome.storage.local.set(payload, () => {
+      console.log(
+        "[Event Attendee Extractor] Saved attendees to storage:",
+        response.attendees.length
+      );
+      sendResponse({ ok: true, attendees: response.attendees });
+    });
+  } catch (error) {
+    console.error("[Event Attendee Extractor] Failed to scrape:", error);
+    sendResponse({
+      ok: false,
+      error: "Could not extract attendees on this page."
+    });
+  }
+}

--- a/event-attendee-extension/content.js
+++ b/event-attendee-extension/content.js
@@ -1,0 +1,206 @@
+const DEBUG_PREFIX = "[Event Attendee Extractor]";
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "EXTRACT_ATTENDEES") {
+    extractAttendees()
+      .then((attendees) => {
+        sendResponse({ ok: true, attendees });
+      })
+      .catch((error) => {
+        console.error(DEBUG_PREFIX, "Extraction error:", error);
+        sendResponse({ ok: false, error: error.message });
+      });
+
+    return true;
+  }
+
+  return false;
+});
+
+async function extractAttendees() {
+  console.log(DEBUG_PREFIX, "Starting attendee extraction.");
+  await autoScroll(8, 800);
+
+  const attendeeCards = collectAttendeeCards();
+  console.log(DEBUG_PREFIX, "Cards discovered:", attendeeCards.length);
+
+  const attendees = [];
+
+  for (const card of attendeeCards) {
+    await tryExpandAttendee(card);
+
+    const attendee = parseAttendeeCard(card);
+    if (!attendee.name) {
+      continue;
+    }
+
+    attendees.push(attendee);
+  }
+
+  const uniqueAttendees = dedupeAttendees(attendees);
+  console.log(DEBUG_PREFIX, "Unique attendees extracted:", uniqueAttendees.length);
+  return uniqueAttendees;
+}
+
+function collectAttendeeCards() {
+  const selectorGroups = [
+    "li.artdeco-list__item",
+    "li.org-people-profile-card",
+    "li.scaffold-finite-scroll__content-item",
+    "div[data-view-name*='event'][role='listitem']",
+    "[role='list'] > li"
+  ];
+
+  const seen = new Set();
+  const cards = [];
+
+  selectorGroups.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((el) => {
+      const text = cleanText(el.innerText);
+      if (text.length < 3) {
+        return;
+      }
+
+      if (!seen.has(el)) {
+        seen.add(el);
+        cards.push(el);
+      }
+    });
+  });
+
+  return cards;
+}
+
+async function tryExpandAttendee(card) {
+  const expandSelectors = [
+    "button[aria-expanded='false']",
+    "button[aria-label*='Show']",
+    "button[aria-label*='Expand']",
+    "button[aria-label*='Contact']"
+  ];
+
+  for (const selector of expandSelectors) {
+    const button = card.querySelector(selector);
+    if (!button) {
+      continue;
+    }
+
+    button.click();
+    console.log(DEBUG_PREFIX, "Clicked expand button.");
+    await sleep(250);
+    break;
+  }
+}
+
+function parseAttendeeCard(card) {
+  const name =
+    firstText(card, [
+      ".artdeco-entity-lockup__title",
+      ".org-people-profile-card__profile-title",
+      "a[href*='/in/']",
+      "span[aria-hidden='true']"
+    ]) ?? "";
+
+  const title =
+    firstText(card, [
+      ".artdeco-entity-lockup__subtitle",
+      ".org-people-profile-card__profile-info",
+      ".t-14.t-normal",
+      ".t-black--light"
+    ]) ?? "";
+
+  const profileLink =
+    card.querySelector("a[href*='/in/']")?.href?.trim() ?? "";
+
+  const cardText = cleanText(card.innerText);
+  const contact = extractContactInfo(card, cardText);
+
+  return {
+    name: cleanText(name),
+    title: cleanText(title),
+    profileLink,
+    email: contact.email,
+    phone: contact.phone,
+    website: contact.website,
+    location: contact.location,
+    rawDetails: cardText
+  };
+}
+
+function extractContactInfo(card, cardText) {
+  const emailRegex =
+    /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/;
+  const phoneRegex =
+    /(\+?\d[\d\s().-]{7,}\d)/;
+
+  const emailMatch = cardText.match(emailRegex);
+  const phoneMatch = cardText.match(phoneRegex);
+
+  const links = Array.from(card.querySelectorAll("a[href]"));
+  const website =
+    links
+      .map((link) => link.href)
+      .find((href) =>
+        href.startsWith("http") &&
+        !href.includes("linkedin.com") &&
+        !href.includes("mailto:")
+      ) ?? "";
+
+  const location =
+    firstText(card, [
+      ".t-12.t-normal.t-black--light",
+      ".org-people-profile-card__profile-location"
+    ]) ?? "";
+
+  return {
+    email: emailMatch?.[1] ?? "",
+    phone: phoneMatch?.[1] ?? "",
+    website,
+    location: cleanText(location)
+  };
+}
+
+function dedupeAttendees(attendees) {
+  const seen = new Set();
+  const unique = [];
+
+  attendees.forEach((attendee) => {
+    const key = `${attendee.name}|${attendee.profileLink}`.toLowerCase();
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    unique.push(attendee);
+  });
+
+  return unique;
+}
+
+function firstText(container, selectors) {
+  for (const selector of selectors) {
+    const value = container.querySelector(selector)?.textContent;
+    if (value && cleanText(value)) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+async function autoScroll(maxPasses, delayMs) {
+  for (let i = 0; i < maxPasses; i += 1) {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+    await sleep(delayMs);
+  }
+
+  window.scrollTo({ top: 0, behavior: "auto" });
+}
+
+function cleanText(value) {
+  return (value || "").replace(/\s+/g, " ").trim();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/event-attendee-extension/manifest.json
+++ b/event-attendee-extension/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": 3,
+  "name": "Event Attendee Extractor",
+  "version": "1.0.0",
+  "description": "Extract attendees from event pages and export to CSV/PDF.",
+  "permissions": [
+    "activeTab",
+    "tabs",
+    "scripting",
+    "storage",
+    "downloads",
+    "sidePanel"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "action": {
+    "default_title": "Event Attendee Extractor"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -1,0 +1,127 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1d2838;
+}
+
+.container {
+  padding: 12px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.status {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #59687a;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.btn {
+  border: 1px solid #c3cfdd;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background: #f0f4fa;
+}
+
+.btn.primary {
+  background: #1f6feb;
+  color: #fff;
+  border-color: #1f6feb;
+}
+
+.results {
+  margin-top: 12px;
+  background: #fff;
+  border: 1px solid #d6deea;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.results-header h2 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.badge {
+  background: #eaf1fb;
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
+.attendee-list {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.attendee-item {
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  background: #fbfdff;
+}
+
+.attendee-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 9px;
+  cursor: pointer;
+}
+
+.attendee-name {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.attendee-title {
+  font-size: 12px;
+  color: #617489;
+}
+
+.attendee-details {
+  border-top: 1px dashed #dbe4ef;
+  padding: 8px 9px;
+  display: none;
+  font-size: 12px;
+  color: #30445c;
+}
+
+.attendee-item.expanded .attendee-details {
+  display: block;
+}
+
+.empty {
+  font-size: 12px;
+  color: #6c7f95;
+  padding: 8px;
+  border: 1px dashed #cdd9e7;
+  border-radius: 8px;
+}

--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Attendee Extractor</title>
+    <link rel="stylesheet" href="sidepanel.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="header">
+        <h1>Event Attendees</h1>
+        <p id="statusText" class="status">Ready to extract attendee data.</p>
+      </header>
+
+      <section class="actions">
+        <button id="scrapeBtn" class="btn primary">Extract attendees</button>
+        <button id="saveBtn" class="btn">Save locally</button>
+        <button id="csvBtn" class="btn">Export CSV</button>
+        <button id="pdfBtn" class="btn">Export PDF</button>
+      </section>
+
+      <section class="results">
+        <div class="results-header">
+          <h2>Attendee List</h2>
+          <span id="countBadge" class="badge">0</span>
+        </div>
+        <div id="attendeeList" class="attendee-list"></div>
+      </section>
+    </main>
+
+    <script src="sidepanel.js"></script>
+  </body>
+</html>

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -1,0 +1,274 @@
+const state = {
+  attendees: []
+};
+
+const attendeeListEl = document.getElementById("attendeeList");
+const statusTextEl = document.getElementById("statusText");
+const countBadgeEl = document.getElementById("countBadge");
+
+document.getElementById("scrapeBtn").addEventListener("click", handleScrape);
+document.getElementById("saveBtn").addEventListener("click", handleSave);
+document.getElementById("csvBtn").addEventListener("click", exportCsv);
+document.getElementById("pdfBtn").addEventListener("click", exportPdf);
+
+init();
+
+async function init() {
+  const response = await sendRuntimeMessage({ type: "GET_LAST_ATTENDEES" });
+
+  if (response?.attendees?.length) {
+    state.attendees = response.attendees;
+    renderAttendees();
+    statusTextEl.textContent =
+      `Loaded ${response.attendees.length} attendees from previous scrape.`;
+  }
+}
+
+async function handleScrape() {
+  setStatus("Extracting attendees from current page...");
+
+  const response = await sendRuntimeMessage({ type: "SCRAPE_ATTENDEES" });
+  if (!response?.ok) {
+    setStatus(response?.error ?? "Failed to extract attendees.");
+    return;
+  }
+
+  state.attendees = response.attendees;
+  renderAttendees();
+  setStatus(`Extracted ${state.attendees.length} attendees.`);
+}
+
+function handleSave() {
+  chrome.storage.local.set(
+    {
+      lastAttendees: state.attendees,
+      lastScrapedAt: new Date().toISOString()
+    },
+    () => {
+      setStatus(`Saved ${state.attendees.length} attendees locally.`);
+    }
+  );
+}
+
+function exportCsv() {
+  if (!state.attendees.length) {
+    setStatus("No attendees available for CSV export.");
+    return;
+  }
+
+  const headers = [
+    "Name",
+    "Title",
+    "Profile Link",
+    "Email",
+    "Phone",
+    "Website",
+    "Location",
+    "Raw Details"
+  ];
+
+  const rows = state.attendees.map((attendee) => [
+    attendee.name,
+    attendee.title,
+    attendee.profileLink,
+    attendee.email,
+    attendee.phone,
+    attendee.website,
+    attendee.location,
+    attendee.rawDetails
+  ]);
+
+  const csv = [headers, ...rows]
+    .map((line) => line.map(escapeCsv).join(","))
+    .join("\n");
+
+  downloadBlob(csv, "text/csv;charset=utf-8", "attendees.csv");
+  setStatus("CSV export complete.");
+}
+
+function exportPdf() {
+  if (!state.attendees.length) {
+    setStatus("No attendees available for PDF export.");
+    return;
+  }
+
+  const pdfContent = buildSimplePdf(state.attendees);
+  const byteArray = new Uint8Array(pdfContent);
+  const blob = new Blob([byteArray], { type: "application/pdf" });
+  downloadBlob(blob, "application/pdf", "attendees.pdf");
+  setStatus("PDF export complete.");
+}
+
+function renderAttendees() {
+  attendeeListEl.innerHTML = "";
+  countBadgeEl.textContent = String(state.attendees.length);
+
+  if (!state.attendees.length) {
+    attendeeListEl.innerHTML =
+      '<div class="empty">No attendees yet. Click "Extract attendees".</div>';
+    return;
+  }
+
+  state.attendees.forEach((attendee, index) => {
+    const item = document.createElement("article");
+    item.className = "attendee-item";
+
+    const summary = document.createElement("div");
+    summary.className = "attendee-summary";
+    summary.innerHTML = `
+      <div>
+        <div class="attendee-name">${escapeHtml(attendee.name || "Unknown")}</div>
+        <div class="attendee-title">${escapeHtml(attendee.title || "")}</div>
+      </div>
+      <div aria-hidden="true">▼</div>
+    `;
+
+    const details = document.createElement("div");
+    details.className = "attendee-details";
+    details.innerHTML = `
+      ${detailRow("Profile", attendee.profileLink)}
+      ${detailRow("Email", attendee.email)}
+      ${detailRow("Phone", attendee.phone)}
+      ${detailRow("Website", attendee.website)}
+      ${detailRow("Location", attendee.location)}
+    `;
+
+    summary.addEventListener("click", () => {
+      item.classList.toggle("expanded");
+      console.log("[Event Attendee Extractor] Toggle attendee:", index);
+    });
+
+    item.appendChild(summary);
+    item.appendChild(details);
+    attendeeListEl.appendChild(item);
+  });
+}
+
+function detailRow(label, value) {
+  const renderedValue = value ? escapeHtml(value) : "-";
+  return `<div><strong>${label}:</strong> ${renderedValue}</div>`;
+}
+
+function sendRuntimeMessage(payload) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(payload, (response) => {
+      if (chrome.runtime.lastError) {
+        console.error(
+          "[Event Attendee Extractor] Runtime message error:",
+          chrome.runtime.lastError
+        );
+        resolve({ ok: false, error: chrome.runtime.lastError.message });
+        return;
+      }
+
+      resolve(response);
+    });
+  });
+}
+
+function setStatus(message) {
+  statusTextEl.textContent = message;
+}
+
+function escapeCsv(value) {
+  const stringValue = String(value ?? "");
+  return `"${stringValue.replaceAll('"', '""')}"`;
+}
+
+function downloadBlob(data, mimeType, filename) {
+  const blob = data instanceof Blob ? data : new Blob([data], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  chrome.downloads.download(
+    {
+      url,
+      filename,
+      saveAs: true
+    },
+    () => {
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }
+  );
+}
+
+function escapeHtml(input) {
+  return String(input ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function buildSimplePdf(attendees) {
+  const lines = ["Event Attendees", ""];
+
+  attendees.forEach((attendee, index) => {
+    lines.push(`${index + 1}. ${safePdfText(attendee.name)}`);
+    lines.push(`Title: ${safePdfText(attendee.title)}`);
+    lines.push(`Email: ${safePdfText(attendee.email)}`);
+    lines.push(`Phone: ${safePdfText(attendee.phone)}`);
+    lines.push(`Website: ${safePdfText(attendee.website)}`);
+    lines.push(`Location: ${safePdfText(attendee.location)}`);
+    lines.push("");
+  });
+
+  const textLines = lines.slice(0, 180);
+
+  let stream = "BT\n/F1 10 Tf\n14 TL\n50 770 Td\n";
+  textLines.forEach((line, i) => {
+    if (i === 0) {
+      stream += `(${escapePdfString(line)}) Tj\n`;
+      return;
+    }
+
+    stream += `T* (${escapePdfString(line)}) Tj\n`;
+  });
+  stream += "ET";
+
+  const objects = [];
+  objects.push("1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj");
+  objects.push("2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj");
+  objects.push(
+    "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] " +
+      "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj"
+  );
+  objects.push("4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj");
+  objects.push(
+    `5 0 obj << /Length ${stream.length} >> stream\n${stream}\nendstream endobj`
+  );
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+
+  objects.forEach((obj) => {
+    offsets.push(pdf.length);
+    pdf += `${obj}\n`;
+  });
+
+  const xrefPos = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+
+  for (let i = 1; i < offsets.length; i += 1) {
+    pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  }
+
+  pdf += "trailer\n";
+  pdf += `<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+  pdf += `startxref\n${xrefPos}\n%%EOF`;
+
+  return new TextEncoder().encode(pdf);
+}
+
+function safePdfText(value) {
+  return String(value ?? "").slice(0, 90);
+}
+
+function escapePdfString(value) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("(", "\\(")
+    .replaceAll(")", "\\)")
+    .replace(/[^\x20-\x7E]/g, " ");
+}


### PR DESCRIPTION
### Motivation
- Provide an in-browser tool to extract attendee lists from event pages and present them in a side panel for quick review. 
- Allow users to expand each attendee to reveal contact details when available and persist or export the results. 
- Support export workflows (CSV and PDF) and local save for later reuse without modifying the source page. 

### Description
- Add a Manifest V3 Chrome extension under `event-attendee-extension/` with `manifest.json` and required permissions for `sidePanel`, `scripting`, `storage`, and `downloads`. 
- Implement `background.js` as a service worker to open the side panel, handle runtime messages (`SCRAPE_ATTENDEES` / `GET_LAST_ATTENDEES`), and persist scrapes to `chrome.storage.local`. 
- Implement `content.js` to extract attendees from the active page with auto-scroll, multiple selector heuristics, expand-click attempts, name/title/contact parsing, and deduplication. 
- Implement side panel UI (`sidepanel.html`, `sidepanel.css`, `sidepanel.js`) to list attendees with expandable detail rows, save locally, `Export CSV`, and `Export PDF` (client-side PDF assembly and download). 
- Add `README.md` documenting install and usage steps. 

### Testing
- Ran `python -m json.tool event-attendee-extension/manifest.json` which completed successfully. 
- Ran `node --check` on `background.js`, `content.js`, and `sidepanel.js` which completed successfully with no syntax errors. 
- All automated checks executed in the environment passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3c176d08832baae7b7ae72c1b059)