### PR TITLE
Fix attendee scraping message delivery

### DIFF
--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -13,7 +13,7 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === "SCRAPE_ATTENDEES") {
-    scrapeFromActiveTab(sendResponse);
+    scrapeFromActiveTab(sendResponse, sender, message?.tabId);
     return true;
   }
 
@@ -30,21 +30,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
-async function scrapeFromActiveTab(sendResponse) {
+async function scrapeFromActiveTab(sendResponse, sender, requestedTabId) {
   try {
-    const [tab] = await chrome.tabs.query({
-      active: true,
-      currentWindow: true
-    });
+    const tabId = await resolveTargetTabId(sender, requestedTabId);
 
-    if (!tab?.id) {
+    if (!tabId) {
       sendResponse({ ok: false, error: "No active tab found." });
       return;
     }
 
-    const response = await chrome.tabs.sendMessage(tab.id, {
-      type: "EXTRACT_ATTENDEES"
-    });
+    const response = await requestAttendeesFromTab(tabId);
 
     if (!response?.ok) {
       sendResponse({
@@ -73,4 +68,52 @@ async function scrapeFromActiveTab(sendResponse) {
       error: "Could not extract attendees on this page."
     });
   }
+}
+
+async function resolveTargetTabId(sender, requestedTabId) {
+  if (Number.isInteger(requestedTabId)) {
+    return requestedTabId;
+  }
+
+  if (sender?.tab?.id) {
+    return sender.tab.id;
+  }
+
+  const [activeTab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true
+  });
+
+  return activeTab?.id ?? null;
+}
+
+async function requestAttendeesFromTab(tabId) {
+  try {
+    return await chrome.tabs.sendMessage(tabId, {
+      type: "EXTRACT_ATTENDEES"
+    });
+  } catch (error) {
+    if (!isReceivingEndMissingError(error)) {
+      throw error;
+    }
+
+    console.log(
+      "[Event Attendee Extractor] Content script unavailable; injecting and retrying.",
+      tabId
+    );
+
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["content.js"]
+    });
+
+    return chrome.tabs.sendMessage(tabId, {
+      type: "EXTRACT_ATTENDEES"
+    });
+  }
+}
+
+function isReceivingEndMissingError(error) {
+  const message = String(error?.message ?? "");
+  return message.includes("Receiving end does not exist");
 }

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -27,7 +27,14 @@ async function init() {
 async function handleScrape() {
   setStatus("Extracting attendees from current page...");
 
-  const response = await sendRuntimeMessage({ type: "SCRAPE_ATTENDEES" });
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  console.log("[Event Attendee Extractor] Scrape requested for tab:", activeTab?.id, activeTab?.url);
+
+  const response = await sendRuntimeMessage({
+    type: "SCRAPE_ATTENDEES",
+    tabId: activeTab?.id
+  });
+
   if (!response?.ok) {
     setStatus(response?.error ?? "Failed to extract attendees.");
     return;


### PR DESCRIPTION
### Motivation
- Side panel scraping intermittently failed because the background script could not reliably target the intended tab or recover when the content script was not present, causing `chrome.tabs.sendMessage` to have no receiver.
- Improve reliability and observability of the scraping flow so extraction works from the side panel across tab contexts.

### Description
- Pass the active tab id from the side panel to the background handler by adding `tabId` to the `SCRAPE_ATTENDEES` message and logging the request in `event-attendee-extension/sidepanel.js`.
- Add `resolveTargetTabId(sender, requestedTabId)` to `event-attendee-extension/background.js` to determine the target tab using the requested `tabId`, the `sender.tab.id`, or an active-tab query fallback.
- Implement `requestAttendeesFromTab(tabId)` which wraps `chrome.tabs.sendMessage`, and on `Receiving end does not exist` injects `content.js` via `chrome.scripting.executeScript` and retries the `EXTRACT_ATTENDEES` request.
- Add helper `isReceivingEndMissingError(error)` and extra console logging to make tab-targeting and reinjection steps observable during debugging.

### Testing
- Performed static checks with `node --check event-attendee-extension/background.js`, which succeeded.
- Performed static checks with `node --check event-attendee-extension/sidepanel.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de432f4ee0832b8055416ac2b603f0)