### PR TITLE
Improve tab targeting and validation for attendee scraping

### DIFF
--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -35,7 +35,7 @@ async function scrapeFromActiveTab(sendResponse, sender, requestedTabId) {
     const tabId = await resolveTargetTabId(sender, requestedTabId);
 
     if (!tabId) {
-      sendResponse({ ok: false, error: "No active tab found." });
+      sendResponse({ ok: false, error: "No valid browser tab found." });
       return;
     }
 
@@ -71,20 +71,52 @@ async function scrapeFromActiveTab(sendResponse, sender, requestedTabId) {
 }
 
 async function resolveTargetTabId(sender, requestedTabId) {
+  const candidates = [];
+
   if (Number.isInteger(requestedTabId)) {
-    return requestedTabId;
+    candidates.push(await safeGetTab(requestedTabId));
   }
 
   if (sender?.tab?.id) {
-    return sender.tab.id;
+    candidates.push(await safeGetTab(sender.tab.id));
   }
 
   const [activeTab] = await chrome.tabs.query({
     active: true,
-    currentWindow: true
+    lastFocusedWindow: true
   });
+  candidates.push(activeTab);
 
-  return activeTab?.id ?? null;
+  const allTabs = await chrome.tabs.query({ lastFocusedWindow: true });
+  const linkedinTabs = allTabs.filter((tab) => tab?.url?.includes("linkedin.com"));
+  candidates.push(...linkedinTabs);
+
+  const validTab = candidates.find((tab) => isScrapableUrl(tab?.url));
+
+  console.log(
+    "[Event Attendee Extractor] Target tab resolution:",
+    candidates
+      .filter(Boolean)
+      .map((tab) => ({ id: tab.id, url: tab.url, scrapable: isScrapableUrl(tab.url) }))
+  );
+
+  return validTab?.id ?? null;
+}
+
+async function safeGetTab(tabId) {
+  try {
+    return await chrome.tabs.get(tabId);
+  } catch {
+    return null;
+  }
+}
+
+function isScrapableUrl(url) {
+  if (!url || typeof url !== "string") {
+    return false;
+  }
+
+  return /^(https?:\/\/)/.test(url);
 }
 
 async function requestAttendeesFromTab(tabId) {


### PR DESCRIPTION
### Motivation
- The scraping flow was failing when the background script attempted to message non-web or restricted tabs (e.g. `chrome://`, extension pages), causing fetches to fail.
- Ensure the extension targets a valid HTTP(S) tab when invoked from the side panel or other contexts so extraction reliably reaches the content script.

### Description
- Reworked tab resolution in `background.js` by collecting candidate tabs from the requested tab, the sender tab, the active tab, and LinkedIn tabs in the focused window, then selecting the first valid HTTP(S) tab via `isScrapableUrl`.
- Added `safeGetTab` to defensively fetch tab objects and avoid throwing on invalid tab ids.
- Replaced ambiguous error text with a clearer response when no valid tab is found (`No valid browser tab found.`) and added diagnostic logging that prints candidate tabs and their `scrapable` status.
- Kept and preserved the existing content-script injection retry path when the receiving end is missing, so behavior on pages without an injected script is unchanged.

### Testing
- Ran syntax checks: `node --check event-attendee-extension/background.js`, `node --check event-attendee-extension/content.js`, and `node --check event-attendee-extension/sidepanel.js`; all checks completed successfully.
- Verified the modified `background.js` loads without runtime parse errors via static checks and logging additions (no automated browser integration tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de44e4897c832bbf52a8c61bdfcee8)