### PR TITLE
Fix LinkedIn attendee pagination and modernize side panel UI

### DIFF
--- a/event-attendee-extension/assets/favicon.svg
+++ b/event-attendee-extension/assets/favicon.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="14" fill="#0A66C2"/>
+  <path d="M18 22C18 20.8954 18.8954 20 20 20H30C31.1046 20 32 20.8954 32 22V44C32 45.1046 31.1046 46 30 46H20C18.8954 46 18 45.1046 18 44V22Z" fill="white"/>
+  <circle cx="22" cy="25" r="2" fill="#0A66C2"/>
+  <path d="M24 30H28" stroke="#0A66C2" stroke-width="2" stroke-linecap="round"/>
+  <path d="M24 35H28" stroke="#0A66C2" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="44" cy="40" r="10" fill="white"/>
+  <path d="M44 35V45" stroke="#0A66C2" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M39 40H49" stroke="#0A66C2" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/event-attendee-extension/assets/logo.svg
+++ b/event-attendee-extension/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="88" height="88" rx="20" fill="#0A66C2"/>
+  <rect x="20" y="18" width="56" height="60" rx="10" fill="white"/>
+  <rect x="28" y="30" width="40" height="6" rx="3" fill="#0A66C2"/>
+  <rect x="28" y="42" width="30" height="6" rx="3" fill="#0A66C2"/>
+  <rect x="28" y="54" width="22" height="6" rx="3" fill="#0A66C2"/>
+  <circle cx="66" cy="64" r="12" fill="#0A66C2"/>
+  <path d="M66 58V70" stroke="white" stroke-width="3" stroke-linecap="round"/>
+  <path d="M60 64H72" stroke="white" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/event-attendee-extension/content.js
+++ b/event-attendee-extension/content.js
@@ -21,64 +21,115 @@ async function extractAttendees() {
   console.log(DEBUG_PREFIX, "Starting attendee extraction.");
 
   const allAttendees = [];
+  const visitedPageKeys = new Set();
+  let pageNumber = 1;
 
-  // Extract current page
-  const cards = collectAttendeeCards();
-  for (const card of cards) {
-const attendee = parseAttendeeCard(card);
-if (attendee) allAttendees.push(attendee);
-  }
+  while (true) {
+    await waitForAttendeeList();
+    await autoScroll(3, 500);
+    const cards = collectAttendeeCards();
+    const pageKey = buildPageKey(cards);
 
-  // Click through remaining pages
-  const nextBtn = document.querySelector('[data-testid="pagination-controls-next-button-visible"]');
-  if (nextBtn) {
-    nextBtn.click();
-    await sleep(2000);
-    const moreCards = collectAttendeeCards();
-    console.log(DEBUG_PREFIX, "Cards found:", cards.length);
-    for (const card of moreCards) {
-const attendee = parseAttendeeCard(card);
-if (attendee) allAttendees.push(attendee);
+    console.log(DEBUG_PREFIX, `Page ${pageNumber}:`, {
+      cards: cards.length,
+      pageKey,
+      url: location.href
+    });
+
+    if (visitedPageKeys.has(pageKey)) {
+      console.log(DEBUG_PREFIX, "Detected repeated page; stopping pagination.");
+      break;
     }
+
+    visitedPageKeys.add(pageKey);
+
+    for (const card of cards) {
+      const attendee = parseAttendeeCard(card);
+      if (attendee) {
+        allAttendees.push(attendee);
+      }
+    }
+
+    const nextBtn = findNextButton();
+    if (!nextBtn || isPaginationButtonDisabled(nextBtn)) {
+      console.log(DEBUG_PREFIX, "No next page button available; extraction complete.");
+      break;
+    }
+
+    const previousUrl = location.href;
+    nextBtn.click();
+    console.log(DEBUG_PREFIX, `Clicked next page from page ${pageNumber}.`);
+
+    const moved = await waitForPageChange(previousUrl, pageKey);
+    if (!moved) {
+      console.log(DEBUG_PREFIX, "Next click did not move to a new page; stopping.");
+      break;
+    }
+
+    pageNumber += 1;
   }
 
-  return dedupeAttendees(allAttendees);
+  const unique = dedupeAttendees(allAttendees);
+  console.log(DEBUG_PREFIX, `Extraction done. Total unique attendees: ${unique.length}`);
+  return unique;
 }
 
 function collectAttendeeCards() {
-  const seen = new Set();
-  const cards = [];
-
-  document.querySelectorAll('[role="listitem"]').forEach((el) => {
-    // Filter out non-person list items (pagination, upsell widgets, etc.)
+  return Array.from(document.querySelectorAll('[role="listitem"]')).filter((el) => {
     const hasProfileOrSearch = el.querySelector('a[href*="/in/"], a[href*="eventAttending"]');
-    if (!hasProfileOrSearch) return;
-    if (seen.has(el)) return;
-    seen.add(el);
-    cards.push(el);
+    return Boolean(hasProfileOrSearch);
   });
-
-  return cards;
 }
 
-async function tryExpandAttendee(card) {
-  const expandSelectors = [
-    "button[aria-expanded='false']",
-    "button[aria-label*='Show']",
-    "button[aria-label*='Expand']",
-    "button[aria-label*='Contact']"
+function findNextButton() {
+  const selectors = [
+    '[data-testid="pagination-controls-next-button-visible"]',
+    'button[aria-label*="Next"]',
+    'button[aria-label*="next"]',
+    'button.artdeco-pagination__button--next'
   ];
 
-  for (const selector of expandSelectors) {
-    const button = card.querySelector(selector);
-    if (!button) {
-      continue;
+  for (const selector of selectors) {
+    const button = document.querySelector(selector);
+    if (button) {
+      return button;
     }
+  }
 
-    button.click();
-    console.log(DEBUG_PREFIX, "Clicked expand button.");
+  return null;
+}
+
+function isPaginationButtonDisabled(button) {
+  if (!button) return true;
+  return button.disabled || button.getAttribute("aria-disabled") === "true";
+}
+
+function buildPageKey(cards) {
+  const firstProfile = cards[0]?.querySelector('a[href*="/in/"]')?.getAttribute("href") || "no-first";
+  const lastProfile = cards[cards.length - 1]?.querySelector('a[href*="/in/"]')?.getAttribute("href") || "no-last";
+  return `${cards.length}|${firstProfile}|${lastProfile}`;
+}
+
+async function waitForPageChange(previousUrl, previousPageKey) {
+  for (let i = 0; i < 25; i += 1) {
     await sleep(250);
-    break;
+    const cards = collectAttendeeCards();
+    const newKey = buildPageKey(cards);
+    if (location.href !== previousUrl || (cards.length > 0 && newKey !== previousPageKey)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function waitForAttendeeList() {
+  for (let i = 0; i < 20; i += 1) {
+    const cards = collectAttendeeCards();
+    if (cards.length > 0) {
+      return;
+    }
+    await sleep(250);
   }
 }
 
@@ -87,43 +138,41 @@ function parseAttendeeCard(card) {
   const name = cleanText(nameAnchor?.textContent ?? "");
   const profileLink = nameAnchor?.href?.split("?")[0] ?? "";
 
-  // Get all non-empty paragraph texts in order
   const paragraphs = Array.from(card.querySelectorAll("p"))
-    .map(p => cleanText(p.textContent))
-    .filter(t => t.length > 0 && t !== name && !t.includes("• "));
+    .map((p) => cleanText(p.textContent))
+    .filter((t) => t.length > 0 && t !== name && !t.includes("• "));
 
   const title = paragraphs[0] ?? "";
   const location = paragraphs[1] ?? "";
-
-  console.log(DEBUG_PREFIX, "Parsed card:", { name, title, location, profileLink });
 
   if (!name || name === "LinkedIn Member") return null;
 
   const cardText = cleanText(card.innerText);
   const contact = extractContactInfo(card, cardText);
 
-  return { name, title, profileLink, email: contact.email, phone: contact.phone,
-           website: contact.website, location, rawDetails: cardText };
+  return {
+    name,
+    title,
+    profileLink,
+    email: contact.email,
+    phone: contact.phone,
+    website: contact.website,
+    location,
+    rawDetails: cardText
+  };
 }
 
 function extractContactInfo(card, cardText) {
-  const emailRegex =
-    /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/;
-  const phoneRegex =
-    /(\+?\d[\d\s().-]{7,}\d)/;
+  const emailRegex = /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/;
+  const phoneRegex = /(\+?\d[\d\s().-]{7,}\d)/;
 
   const emailMatch = cardText.match(emailRegex);
   const phoneMatch = cardText.match(phoneRegex);
 
   const links = Array.from(card.querySelectorAll("a[href]"));
-  const website =
-    links
-      .map((link) => link.href)
-      .find((href) =>
-        href.startsWith("http") &&
-        !href.includes("linkedin.com") &&
-        !href.includes("mailto:")
-      ) ?? "";
+  const website = links
+    .map((link) => link.href)
+    .find((href) => href.startsWith("http") && !href.includes("linkedin.com") && !href.includes("mailto:")) ?? "";
 
   const location =
     firstText(card, [

--- a/event-attendee-extension/manifest.json
+++ b/event-attendee-extension/manifest.json
@@ -20,8 +20,17 @@
   "side_panel": {
     "default_path": "sidepanel.html"
   },
+  "icons": {
+    "16": "assets/favicon.svg",
+    "48": "assets/logo.svg",
+    "128": "assets/logo.svg"
+  },
   "action": {
-    "default_title": "Event Attendee Extractor"
+    "default_title": "Event Attendee Extractor",
+    "default_icon": {
+      "16": "assets/favicon.svg",
+      "48": "assets/logo.svg"
+    }
   },
   "content_scripts": [
     {

--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -1,128 +1,138 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
   color-scheme: light;
-  --bg: #f7f8fa;
+  --linkedin-blue: #0a66c2;
+  --linkedin-blue-hover: #004182;
+  --linkedin-blue-soft: #e8f3ff;
+  --bg: #f3f2ef;
   --surface: #ffffff;
-  --border: #e4e7ec;
-  --border-subtle: #f0f2f5;
-  --text-primary: #111827;
-  --text-secondary: #6b7280;
-  --text-muted: #9ca3af;
-  --accent: #2563eb;
-  --accent-light: #eff6ff;
-  --accent-hover: #1d4ed8;
-  --tag-bg: #f3f4f6;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.07), 0 1px 2px rgba(0,0,0,0.04);
-  --radius: 10px;
-  --radius-sm: 6px;
+  --surface-muted: #f9fafb;
+  --border: #dce6f1;
+  --border-subtle: #ebeff3;
+  --text-primary: #1d2226;
+  --text-secondary: #5f6b7a;
+  --text-muted: #8895a7;
+  --success: #057642;
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.05);
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: 'DM Sans', sans-serif;
-  background: var(--bg);
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(180deg, #f9fbff 0%, var(--bg) 100%);
   color: var(--text-primary);
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 .container {
-  padding: 16px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
 .header {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 12px;
+}
+
+.brand-row {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand-logo {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
 }
 
 .header h1 {
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: -0.2px;
-  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
 }
 
 .status {
   font-size: 11.5px;
-  color: var(--text-muted);
-  font-family: 'DM Mono', monospace;
+  color: var(--text-secondary);
 }
 
-/* Actions */
 .actions {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 10px;
 }
 
 .btn {
-  border: 1px solid var(--border);
+  border: 1px solid #b7c9dd;
   background: var(--surface);
-  border-radius: var(--radius-sm);
-  padding: 7px 10px;
+  border-radius: 999px;
+  padding: 8px 12px;
   font-size: 12px;
-  font-family: 'DM Sans', sans-serif;
-  font-weight: 500;
-  color: var(--text-primary);
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  color: var(--linkedin-blue);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-  box-shadow: var(--shadow-sm);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
   width: 100%;
 }
 
 .btn:hover {
-  background: var(--tag-bg);
-  border-color: #d1d5db;
+  background: var(--linkedin-blue-soft);
+  border-color: #8ab4e2;
 }
 
 .btn.primary {
-  background: var(--accent);
+  background: var(--linkedin-blue);
   color: #fff;
-  border-color: var(--accent);
-  padding: 9px;
-  font-size: 12.5px;
-  letter-spacing: 0.1px;
+  border-color: var(--linkedin-blue);
 }
 
 .btn.primary:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
+  background: var(--linkedin-blue-hover);
+  border-color: var(--linkedin-blue-hover);
 }
 
-/* Export row: select + button side by side */
 .export-row {
   display: flex;
-  gap: 6px;
+  gap: 8px;
 }
 
 .crm-select {
   flex: 1;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 7px 8px;
+  border-radius: 10px;
+  padding: 8px 10px;
   font-size: 12px;
-  font-family: 'DM Sans', sans-serif;
-  font-weight: 500;
+  font-family: 'Inter', sans-serif;
   color: var(--text-primary);
   background: var(--surface);
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%239ca3af' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M1 1l4.5 5L10 1' stroke='%235f6b7a' stroke-width='1.4' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 8px center;
+  background-position: right 9px center;
   padding-right: 24px;
 }
 
 .crm-select:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--linkedin-blue);
+  box-shadow: 0 0 0 2px rgba(10, 102, 194, 0.12);
 }
 
 .export-btn {
@@ -131,7 +141,6 @@ body {
   flex-shrink: 0;
 }
 
-/* Results panel */
 .results {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -144,63 +153,92 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 11px 14px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-muted);
 }
 
 .results-header h2 {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.6px;
+  letter-spacing: 0.4px;
   color: var(--text-secondary);
 }
 
+.results-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.view-toggle {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px;
+  background: #fff;
+}
+
+.view-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.view-btn.active {
+  background: var(--linkedin-blue-soft);
+  color: var(--linkedin-blue-hover);
+}
+
 .badge {
-  background: var(--accent);
+  background: var(--linkedin-blue);
   color: #fff;
   border-radius: 999px;
   padding: 2px 8px;
   font-size: 11px;
-  font-weight: 600;
-  font-family: 'DM Mono', monospace;
-  min-width: 22px;
+  font-weight: 700;
+  min-width: 24px;
   text-align: center;
 }
 
 .attendee-list {
   display: flex;
   flex-direction: column;
+  max-height: calc(100vh - 270px);
+  overflow-y: auto;
 }
 
 .attendee-item {
   border-bottom: 1px solid var(--border-subtle);
-  transition: background 0.1s;
 }
 
-.attendee-item:last-child {
-  border-bottom: none;
-}
+.attendee-item:last-child { border-bottom: none; }
 
 .attendee-summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 10px 12px;
   cursor: pointer;
   user-select: none;
 }
 
 .attendee-summary:hover {
-  background: #fafbfc;
+  background: #f8fbff;
 }
 
 .attendee-info { flex: 1; min-width: 0; }
 
 .attendee-name {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -218,7 +256,7 @@ body {
 .attendee-location {
   font-size: 11px;
   color: var(--text-muted);
-  margin-top: 1px;
+  margin-top: 2px;
 }
 
 .chevron {
@@ -228,50 +266,47 @@ body {
   flex-shrink: 0;
 }
 
-.attendee-item.expanded .chevron {
-  transform: rotate(180deg);
-}
+.attendee-item.expanded .chevron { transform: rotate(180deg); }
 
 .attendee-details {
   display: none;
-  padding: 8px 14px 12px;
-  background: var(--accent-light);
-  border-top: 1px solid #dbeafe;
+  padding: 8px 12px 10px;
+  background: #f7fbff;
+  border-top: 1px solid #d8eaff;
   font-size: 11.5px;
-  color: var(--text-secondary);
   gap: 4px;
   flex-direction: column;
 }
 
-.attendee-item.expanded .attendee-details {
+.attendee-item.expanded .attendee-details { display: flex; }
+
+.detail-row { display: flex; gap: 6px; }
+.detail-label { color: var(--text-muted); font-weight: 600; min-width: 50px; font-size: 11px; }
+.detail-value { color: var(--text-primary); word-break: break-all; }
+.detail-value a { color: var(--linkedin-blue); text-decoration: none; }
+.detail-value a:hover { text-decoration: underline; }
+
+.attendee-list.card-view {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  padding: 8px;
+}
+
+.attendee-list.card-view .attendee-item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.attendee-list.card-view .attendee-summary {
+  align-items: flex-start;
+}
+
+.attendee-list.card-view .attendee-details {
   display: flex;
-}
-
-.detail-row {
-  display: flex;
-  gap: 6px;
-}
-
-.detail-label {
-  color: var(--text-muted);
-  font-weight: 500;
-  min-width: 48px;
-  font-family: 'DM Mono', monospace;
-  font-size: 11px;
-}
-
-.detail-value {
-  color: var(--text-primary);
-  word-break: break-all;
-}
-
-.detail-value a {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-.detail-value a:hover {
-  text-decoration: underline;
 }
 
 .empty {
@@ -285,5 +320,5 @@ body {
 .empty-icon {
   font-size: 22px;
   margin-bottom: 6px;
-  opacity: 0.5;
+  opacity: 0.6;
 }

--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -4,13 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Attendee Extractor</title>
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="stylesheet" href="sidepanel.css" />
   </head>
   <body>
     <main class="container">
       <header class="header">
-        <h1>Event Attendees</h1>
-        <p id="statusText" class="status">Ready to extract.</p>
+        <div class="brand-row">
+          <img src="assets/logo.svg" class="brand-logo" alt="Event Attendee Extractor logo" />
+          <div>
+            <h1>Event Attendees</h1>
+            <p id="statusText" class="status">Ready to extract.</p>
+          </div>
+        </div>
       </header>
 
       <section class="actions">
@@ -34,7 +40,13 @@
       <section class="results">
         <div class="results-header">
           <h2>Attendee List</h2>
-          <span id="countBadge" class="badge">0</span>
+          <div class="results-header-right">
+            <div class="view-toggle" role="group" aria-label="Attendee display mode">
+              <button id="detailedViewBtn" class="view-btn active" type="button">Detailed</button>
+              <button id="cardViewBtn" class="view-btn" type="button">Cards</button>
+            </div>
+            <span id="countBadge" class="badge">0</span>
+          </div>
         </div>
         <div id="attendeeList" class="attendee-list"></div>
       </section>

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -1,19 +1,27 @@
-const state = { attendees: [] };
+const state = { attendees: [], viewMode: "detailed" };
 
 const attendeeListEl = document.getElementById("attendeeList");
-const statusTextEl   = document.getElementById("statusText");
-const countBadgeEl   = document.getElementById("countBadge");
-const crmSelectEl    = document.getElementById("crmSelect");
+const statusTextEl = document.getElementById("statusText");
+const countBadgeEl = document.getElementById("countBadge");
+const crmSelectEl = document.getElementById("crmSelect");
+const detailedViewBtn = document.getElementById("detailedViewBtn");
+const cardViewBtn = document.getElementById("cardViewBtn");
 
 document.getElementById("scrapeBtn").addEventListener("click", handleScrape);
 document.getElementById("saveBtn").addEventListener("click", handleSave);
 document.getElementById("csvBtn").addEventListener("click", exportCsv);
 document.getElementById("pdfBtn").addEventListener("click", exportPdf);
+detailedViewBtn.addEventListener("click", () => setViewMode("detailed"));
+cardViewBtn.addEventListener("click", () => setViewMode("card"));
 
-// Persist the last-used CRM selection
-chrome.storage.local.get(["lastCrm"], (r) => {
+chrome.storage.local.get(["lastCrm", "attendeeViewMode"], (r) => {
   if (r.lastCrm) crmSelectEl.value = r.lastCrm;
+  if (r.attendeeViewMode === "card" || r.attendeeViewMode === "detailed") {
+    state.viewMode = r.attendeeViewMode;
+  }
+  syncViewModeUI();
 });
+
 crmSelectEl.addEventListener("change", () => {
   chrome.storage.local.set({ lastCrm: crmSelectEl.value });
 });
@@ -54,7 +62,10 @@ function handleSave() {
 }
 
 function exportCsv() {
-  if (!state.attendees.length) { setStatus("No attendees to export."); return; }
+  if (!state.attendees.length) {
+    setStatus("No attendees to export.");
+    return;
+  }
 
   const crm = crmSelectEl.value;
   const profile = window.CRM_PROFILES[crm] ?? window.CRM_PROFILES.generic;
@@ -66,15 +77,36 @@ function exportCsv() {
 }
 
 function exportPdf() {
-  if (!state.attendees.length) { setStatus("No attendees to export."); return; }
+  if (!state.attendees.length) {
+    setStatus("No attendees to export.");
+    return;
+  }
   const pdfContent = buildSimplePdf(state.attendees);
   downloadBlob(new Blob([new Uint8Array(pdfContent)], { type: "application/pdf" }), "application/pdf", `attendees-${datestamp()}.pdf`);
   setStatus("PDF exported.");
 }
 
+function setViewMode(mode) {
+  if (mode !== "card" && mode !== "detailed") {
+    return;
+  }
+
+  state.viewMode = mode;
+  chrome.storage.local.set({ attendeeViewMode: mode });
+  syncViewModeUI();
+  renderAttendees();
+}
+
+function syncViewModeUI() {
+  attendeeListEl.classList.toggle("card-view", state.viewMode === "card");
+  detailedViewBtn.classList.toggle("active", state.viewMode === "detailed");
+  cardViewBtn.classList.toggle("active", state.viewMode === "card");
+}
+
 function renderAttendees() {
   attendeeListEl.innerHTML = "";
   countBadgeEl.textContent = String(state.attendees.length);
+  syncViewModeUI();
 
   if (!state.attendees.length) {
     attendeeListEl.innerHTML = `
@@ -97,28 +129,30 @@ function renderAttendees() {
       <div class="attendee-summary">
         <div class="attendee-info">
           <div class="attendee-name">${escapeHtml(attendee.name || "Unknown")}</div>
-          ${attendee.title    ? `<div class="attendee-title">${escapeHtml(attendee.title)}</div>` : ""}
+          ${attendee.title ? `<div class="attendee-title">${escapeHtml(attendee.title)}</div>` : ""}
           ${attendee.location ? `<div class="attendee-location">📍 ${escapeHtml(attendee.location)}</div>` : ""}
         </div>
         <span class="chevron">▼</span>
       </div>
       <div class="attendee-details">
         ${attendee.profileLink ? `<div class="detail-row"><span class="detail-label">Profile</span><span class="detail-value"><a ${profileHref}>LinkedIn ↗</a></span></div>` : ""}
-        ${attendee.email   ? `<div class="detail-row"><span class="detail-label">Email</span><span class="detail-value">${escapeHtml(attendee.email)}</span></div>`   : ""}
-        ${attendee.phone   ? `<div class="detail-row"><span class="detail-label">Phone</span><span class="detail-value">${escapeHtml(attendee.phone)}</span></div>`   : ""}
+        ${attendee.email ? `<div class="detail-row"><span class="detail-label">Email</span><span class="detail-value">${escapeHtml(attendee.email)}</span></div>` : ""}
+        ${attendee.phone ? `<div class="detail-row"><span class="detail-label">Phone</span><span class="detail-value">${escapeHtml(attendee.phone)}</span></div>` : ""}
         ${attendee.website ? `<div class="detail-row"><span class="detail-label">Web</span><span class="detail-value"><a href="${escapeHtml(attendee.website)}" target="_blank">${escapeHtml(attendee.website)}</a></span></div>` : ""}
       </div>
     `;
 
-    item.querySelector(".attendee-summary").addEventListener("click", () => {
-      item.classList.toggle("expanded");
-    });
+    if (state.viewMode === "detailed") {
+      item.querySelector(".attendee-summary").addEventListener("click", () => {
+        item.classList.toggle("expanded");
+      });
+    } else {
+      item.classList.add("expanded");
+    }
 
     attendeeListEl.appendChild(item);
   });
 }
-
-// ── Helpers ────────────────────────────────────────────────────────────────
 
 function sendRuntimeMessage(payload) {
   return new Promise((resolve) => {
@@ -132,7 +166,9 @@ function sendRuntimeMessage(payload) {
   });
 }
 
-function setStatus(msg) { statusTextEl.textContent = msg; }
+function setStatus(msg) {
+  statusTextEl.textContent = msg;
+}
 
 function datestamp() {
   return new Date().toISOString().slice(0, 10);
@@ -148,8 +184,10 @@ function downloadBlob(data, mimeType, filename) {
 
 function escapeHtml(input) {
   return String(input ?? "")
-    .replaceAll("&", "&amp;").replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;").replaceAll('"', "&quot;")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
     .replaceAll("'", "&#039;");
 }
 
@@ -157,8 +195,8 @@ function buildSimplePdf(attendees) {
   const lines = ["Event Attendees", ""];
   attendees.forEach((a, i) => {
     lines.push(`${i + 1}. ${safePdfText(a.name)}`);
-    if (a.title)       lines.push(`   ${safePdfText(a.title)}`);
-    if (a.location)    lines.push(`   ${safePdfText(a.location)}`);
+    if (a.title) lines.push(`   ${safePdfText(a.title)}`);
+    if (a.location) lines.push(`   ${safePdfText(a.location)}`);
     if (a.profileLink) lines.push(`   ${safePdfText(a.profileLink)}`);
     lines.push("");
   });
@@ -182,16 +220,23 @@ function buildSimplePdf(attendees) {
 
   let pdf = "%PDF-1.4\n";
   const offsets = [0];
-  objects.forEach(obj => { offsets.push(pdf.length); pdf += `${obj}\n`; });
+  objects.forEach((obj) => {
+    offsets.push(pdf.length);
+    pdf += `${obj}\n`;
+  });
   const xrefPos = pdf.length;
   pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
-  for (let i = 1; i < offsets.length; i++) pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  for (let i = 1; i < offsets.length; i += 1) {
+    pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  }
   pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefPos}\n%%EOF`;
   return new TextEncoder().encode(pdf);
 }
 
-function safePdfText(v) { return String(v ?? "").slice(0, 90); }
+function safePdfText(v) {
+  return String(v ?? "").slice(0, 90);
+}
 
 function escapePdfString(v) {
-  return v.replaceAll("\\","\\\\").replaceAll("(","\\(").replaceAll(")","\\)").replace(/[^\x20-\x7E]/g," ");
+  return v.replaceAll("\\", "\\\\").replaceAll("(", "\\(").replaceAll(")", "\\)").replace(/[^\x20-\x7E]/g, " ");
 }


### PR DESCRIPTION
### Motivation
- Attendee extraction stopped after the first page(s) when scraping LinkedIn event attendees, so pagination needed to be made reliable across all available pages. 
- The side panel UI was visually inconsistent and needed a more professional, LinkedIn-inspired look with clearer controls and branding. 
- Users wanted an improved attendee presentation with an option to view results as compact cards or expanded detailed entries and to persist that preference.

### Description
- Made pagination robust in `content.js` by adding a pagination loop, `visitedPageKeys` to detect repeated pages, `findNextButton`/`isPaginationButtonDisabled` fallbacks, `waitForPageChange` detection, `waitForAttendeeList` and improved `autoScroll`, and preserved deduplication logic. 
- Reworked the side panel UI by updating `sidepanel.html` and `sidepanel.css` to use LinkedIn-themed colors, improved spacing/typography, header branding and polished controls, and added favicon & logo assets under `assets/`. 
- Added an attendee display mode toggle in `sidepanel.js` (`detailed` vs `card`), persisted the choice to `chrome.storage.local`, and updated rendering so card view shows expanded details while detailed view retains collapsible rows. 
- Updated `manifest.json` to include new icon entries and wired the favicon/logo into the side panel markup.

### Testing
- Ran syntax checks for the modified scripts with `node --check event-attendee-extension/content.js` and `node --check event-attendee-extension/sidepanel.js`, both succeeded. 
- Validated `manifest.json` with `python -m json.tool event-attendee-extension/manifest.json >/dev/null`, which succeeded. 
- Manual console logging was added to `content.js` to assist future pagination debugging in DevTools (no UI automation tests were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9e708a50832bb4d18a41159540e1)