### PR TITLE
Add PRO export paywall and attendee scrape limit

### DIFF
--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -18,7 +18,7 @@ chrome.action.onClicked.addListener(async (tab) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === "SCRAPE_ATTENDEES") {
-    scrapeFromActiveTab(sendResponse, sender, message?.tabId);
+    scrapeFromActiveTab(sendResponse, sender, message?.tabId, message?.attendeeLimit);
     return true;
   }
 
@@ -35,7 +35,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
-async function scrapeFromActiveTab(sendResponse, sender, requestedTabId) {
+async function scrapeFromActiveTab(sendResponse, sender, requestedTabId, attendeeLimit) {
   try {
     const tabId = await resolveTargetTabId(sender, requestedTabId);
 
@@ -44,7 +44,7 @@ async function scrapeFromActiveTab(sendResponse, sender, requestedTabId) {
       return;
     }
 
-    const response = await requestAttendeesFromTab(tabId);
+    const response = await requestAttendeesFromTab(tabId, attendeeLimit);
 
     if (!response?.ok) {
       sendResponse({
@@ -121,10 +121,14 @@ function isScrapableUrl(url) {
   return url.includes("linkedin.com") && /^https?:\/\//.test(url);
 }
 
-async function requestAttendeesFromTab(tabId) {
+async function requestAttendeesFromTab(tabId, attendeeLimit) {
+  const maxAttendees = Number.isInteger(attendeeLimit) && attendeeLimit > 0 ? attendeeLimit : 100;
+  console.log("[Event Attendee Extractor] Requesting attendees with limit:", maxAttendees);
+
   try {
     return await chrome.tabs.sendMessage(tabId, {
-      type: "EXTRACT_ATTENDEES"
+      type: "EXTRACT_ATTENDEES",
+      maxAttendees
     });
   } catch (error) {
     if (!isReceivingEndMissingError(error)) {
@@ -142,7 +146,8 @@ async function requestAttendeesFromTab(tabId) {
     });
 
     return chrome.tabs.sendMessage(tabId, {
-      type: "EXTRACT_ATTENDEES"
+      type: "EXTRACT_ATTENDEES",
+      maxAttendees
     });
   }
 }

--- a/event-attendee-extension/content.js
+++ b/event-attendee-extension/content.js
@@ -2,7 +2,7 @@ const DEBUG_PREFIX = "[Event Attendee Extractor]";
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === "EXTRACT_ATTENDEES") {
-    extractAttendees()
+    extractAttendees(message?.maxAttendees)
       .then((attendees) => {
         sendResponse({ ok: true, attendees });
       })
@@ -17,8 +17,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
-async function extractAttendees() {
+async function extractAttendees(maxAttendeesInput) {
+  const maxAttendees = Number.isInteger(maxAttendeesInput) && maxAttendeesInput > 0 ? maxAttendeesInput : 100;
   console.log(DEBUG_PREFIX, "Starting attendee extraction.");
+  console.log(DEBUG_PREFIX, "Max attendees limit:", maxAttendees);
 
   const allAttendees = [];
   const visitedPageKeys = new Set();
@@ -47,6 +49,12 @@ async function extractAttendees() {
       const attendee = parseAttendeeCard(card);
       if (attendee) {
         allAttendees.push(attendee);
+        if (allAttendees.length >= maxAttendees) {
+          console.log(DEBUG_PREFIX, `Reached attendee limit (${maxAttendees}); stopping pagination.`);
+          const uniqueLimited = dedupeAttendees(allAttendees).slice(0, maxAttendees);
+          console.log(DEBUG_PREFIX, `Extraction done. Total unique attendees: ${uniqueLimited.length}`);
+          return uniqueLimited;
+        }
       }
     }
 

--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -77,6 +77,34 @@ body {
   padding: 10px;
 }
 
+.limit-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.limit-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.limit-input {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: 'Inter', sans-serif;
+  color: var(--text-primary);
+  background: var(--surface);
+}
+
+.limit-input:focus {
+  outline: none;
+  border-color: var(--linkedin-blue);
+  box-shadow: 0 0 0 2px rgba(10, 102, 194, 0.12);
+}
+
 .btn {
   border: 1px solid #b7c9dd;
   background: var(--surface);
@@ -94,6 +122,14 @@ body {
 .btn:hover {
   background: var(--linkedin-blue-soft);
   border-color: #8ab4e2;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: #f5f7fa;
+  border-color: var(--border);
+  color: var(--text-secondary);
 }
 
 .btn.primary {
@@ -139,6 +175,11 @@ body {
   width: auto;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.pro-hint {
+  font-size: 11px;
+  color: var(--text-secondary);
 }
 
 .results {

--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -21,6 +21,10 @@
 
       <section class="actions">
         <button id="scrapeBtn" class="btn primary">Extract attendees</button>
+        <div class="limit-row">
+          <label for="attendeeLimitInput" class="limit-label">Max attendees per scrape</label>
+          <input id="attendeeLimitInput" class="limit-input" type="number" min="1" step="1" value="100" />
+        </div>
         <button id="saveBtn" class="btn">Save locally</button>
 
         <div class="export-row">
@@ -35,6 +39,7 @@
         </div>
 
         <button id="pdfBtn" class="btn">Export PDF</button>
+        <p id="proHint" class="pro-hint" hidden>Export is a PRO feature. Upgrade to unlock CSV/PDF export.</p>
       </section>
 
       <section class="results">

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -1,4 +1,4 @@
-const state = { attendees: [], viewMode: "detailed" };
+const state = { attendees: [], viewMode: "detailed", attendeeLimit: 100, isProUser: false };
 
 const attendeeListEl = document.getElementById("attendeeList");
 const statusTextEl = document.getElementById("statusText");
@@ -6,25 +6,36 @@ const countBadgeEl = document.getElementById("countBadge");
 const crmSelectEl = document.getElementById("crmSelect");
 const detailedViewBtn = document.getElementById("detailedViewBtn");
 const cardViewBtn = document.getElementById("cardViewBtn");
+const attendeeLimitInputEl = document.getElementById("attendeeLimitInput");
+const proHintEl = document.getElementById("proHint");
+const csvBtnEl = document.getElementById("csvBtn");
+const pdfBtnEl = document.getElementById("pdfBtn");
 
 document.getElementById("scrapeBtn").addEventListener("click", handleScrape);
 document.getElementById("saveBtn").addEventListener("click", handleSave);
-document.getElementById("csvBtn").addEventListener("click", exportCsv);
-document.getElementById("pdfBtn").addEventListener("click", exportPdf);
+csvBtnEl.addEventListener("click", exportCsv);
+pdfBtnEl.addEventListener("click", exportPdf);
 detailedViewBtn.addEventListener("click", () => setViewMode("detailed"));
 cardViewBtn.addEventListener("click", () => setViewMode("card"));
 
-chrome.storage.local.get(["lastCrm", "attendeeViewMode"], (r) => {
+chrome.storage.local.get(["lastCrm", "attendeeViewMode", "attendeeLimit", "isProUser"], (r) => {
   if (r.lastCrm) crmSelectEl.value = r.lastCrm;
   if (r.attendeeViewMode === "card" || r.attendeeViewMode === "detailed") {
     state.viewMode = r.attendeeViewMode;
   }
+  if (Number.isInteger(r.attendeeLimit) && r.attendeeLimit > 0) {
+    state.attendeeLimit = r.attendeeLimit;
+  }
+  state.isProUser = Boolean(r.isProUser);
+  attendeeLimitInputEl.value = String(state.attendeeLimit);
+  syncExportPaywallUI();
   syncViewModeUI();
 });
 
 crmSelectEl.addEventListener("change", () => {
   chrome.storage.local.set({ lastCrm: crmSelectEl.value });
 });
+attendeeLimitInputEl.addEventListener("change", handleAttendeeLimitChange);
 
 init();
 
@@ -41,8 +52,13 @@ async function handleScrape() {
   setStatus("Extracting…");
   const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
   console.log("[Event Attendee Extractor] Scrape requested for tab:", activeTab?.id, activeTab?.url);
+  console.log("[Event Attendee Extractor] Scrape attendee limit:", state.attendeeLimit);
 
-  const response = await sendRuntimeMessage({ type: "SCRAPE_ATTENDEES", tabId: activeTab?.id });
+  const response = await sendRuntimeMessage({
+    type: "SCRAPE_ATTENDEES",
+    tabId: activeTab?.id,
+    attendeeLimit: state.attendeeLimit
+  });
 
   if (!response?.ok) {
     setStatus(response?.error ?? "Extraction failed.");
@@ -62,6 +78,11 @@ function handleSave() {
 }
 
 function exportCsv() {
+  if (!state.isProUser) {
+    setStatus("Export is available on PRO.");
+    return;
+  }
+
   if (!state.attendees.length) {
     setStatus("No attendees to export.");
     return;
@@ -77,6 +98,11 @@ function exportCsv() {
 }
 
 function exportPdf() {
+  if (!state.isProUser) {
+    setStatus("Export is available on PRO.");
+    return;
+  }
+
   if (!state.attendees.length) {
     setStatus("No attendees to export.");
     return;
@@ -84,6 +110,20 @@ function exportPdf() {
   const pdfContent = buildSimplePdf(state.attendees);
   downloadBlob(new Blob([new Uint8Array(pdfContent)], { type: "application/pdf" }), "application/pdf", `attendees-${datestamp()}.pdf`);
   setStatus("PDF exported.");
+}
+
+function handleAttendeeLimitChange() {
+  const parsed = Number.parseInt(attendeeLimitInputEl.value, 10);
+  const nextLimit = Number.isInteger(parsed) && parsed > 0 ? parsed : 100;
+  state.attendeeLimit = nextLimit;
+  attendeeLimitInputEl.value = String(nextLimit);
+  chrome.storage.local.set({ attendeeLimit: nextLimit });
+}
+
+function syncExportPaywallUI() {
+  csvBtnEl.disabled = !state.isProUser;
+  pdfBtnEl.disabled = !state.isProUser;
+  proHintEl.hidden = state.isProUser;
 }
 
 function setViewMode(mode) {


### PR DESCRIPTION
### Motivation
- Prevent very long extraction runs on large events by allowing users to cap the number of attendees scraped per run with a simple numeric input (default `100`).
- Protect CSV/PDF export behind a PRO gate so exports can be unlocked for paying users.

### Description
- Add a `Max attendees per scrape` numeric input to the side panel (`sidepanel.html`) with UI styling and persisted value via `chrome.storage.local` (`sidepanel.css`, `sidepanel.js`).
- Thread the limit through the flow by sending `attendeeLimit` from the side panel to the background (`SCRAPE_ATTENDEES` message) and then as `maxAttendees` to the content script (`background.js`).
- Stop pagination early inside the content script when the configured `maxAttendees` is reached and return a deduplicated, truncated attendee list (`content.js`).
- Add a simple PRO paywall UI: maintain `isProUser` from storage, disable export buttons and show a PRO hint when false, and prevent export actions in `exportCsv`/`exportPdf` when not PRO; include disabled button styling (`sidepanel.js`, `sidepanel.css`).

### Testing
- Ran syntax/parse checks with `node --check` on `event-attendee-extension/sidepanel.js`, `background.js`, `content.js`, and `crm-export.js`, and all checks passed. 
- No automated unit/integration tests were present or executed beyond the `node --check` validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb7e5b1a4832ba7eaf38ce3bc605b)