### PR TITLE
Add extension sign-in callback flow for Supabase auth

### DIFF
--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -2,7 +2,7 @@
 chrome.runtime.onInstalled.addListener(() => {
   chrome.storage.local.set({
     supabaseAnonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZoZW1xZ2p3cWpxZ2pxcm5qaHZtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxNTUyNDcsImV4cCI6MjA5MTczMTI0N30.Gyt1fxQgwM3_WFt6yEri-wRxvIg4m_z2TjjbwyzLOfI",
-    supabaseUrl: "https://vhemqgjwqjqgjqrnjhvm.supabase.co",
+    supabaseUrl: "https://vhemqgjwjqgjqrnjhvm.supabase.co",
     appUrl: "https://prospectin.vercel.app"
   });
 });
@@ -29,6 +29,27 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         lastScrapedAt: result.lastScrapedAt ?? null
       });
     });
+    return true;
+  }
+
+  if (message?.type === "SUPABASE_AUTH_CALLBACK") {
+    storeSupabaseSession(message?.session)
+      .then((result) => sendResponse(result))
+      .catch((error) => {
+        console.error("[Event Attendee Extractor] Failed to store callback session:", error);
+        sendResponse({ success: false, error: "Failed to store callback session." });
+      });
+    return true;
+  }
+
+  if (message?.type === "AUTH_SUCCESS_CALLBACK") {
+    chrome.runtime.sendMessage({
+      type: "AUTH_STATE_CHANGED",
+      email: message?.email || null,
+      at: Date.now(),
+    }).catch(() => {});
+
+    sendResponse({ success: true });
     return true;
   }
 
@@ -155,4 +176,47 @@ async function requestAttendeesFromTab(tabId, attendeeLimit) {
 function isReceivingEndMissingError(error) {
   const message = String(error?.message ?? "");
   return message.includes("Receiving end does not exist");
+}
+
+async function storeSupabaseSession(session) {
+  if (!session?.access_token) {
+    return { success: false, error: "Missing access token in callback." };
+  }
+
+  const userFromToken = session?.user?.id ? session.user : null;
+  const user = userFromToken || (await fetchSupabaseUser(session.access_token));
+
+  if (!user?.id) {
+    return { success: false, error: "Unable to resolve signed in user from callback token." };
+  }
+
+  const normalizedSession = {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token || "",
+    expires_at: session.expires_at || null,
+    token_type: session.token_type || "bearer",
+    user,
+  };
+
+  await chrome.storage.local.set({ session: normalizedSession });
+
+  return {
+    success: true,
+    session: normalizedSession,
+  };
+}
+
+async function fetchSupabaseUser(accessToken) {
+  const { supabaseUrl, supabaseAnonKey } = await chrome.storage.local.get(["supabaseUrl", "supabaseAnonKey"]);
+  if (!supabaseUrl || !supabaseAnonKey) return null;
+
+  const res = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) return null;
+  return res.json();
 }

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -3,6 +3,7 @@ const FREE_LIMIT = 20;
 const DEFAULT_SUPABASE_URL = "https://vhemqgjwjqgjqrnjhvm.supabase.co";
 const DEFAULT_APP_URL = "https://prospectin.vercel.app";
 const SYNC_INTERVAL_MS = 15000;
+const SIGNIN_CALLBACK_PATH = "signin-callback.html";
 
 // ── State ─────────────────────────────────────────────────────────────────────
 const state = {
@@ -401,7 +402,7 @@ async function handleMagicLink() {
   $("magicLinkBtn").textContent = "Sending…";
 
   try {
-    const redirectTo = `${state.config.appUrl}/auth/callback`;
+    const redirectTo = chrome.runtime.getURL(SIGNIN_CALLBACK_PATH);
     const res = await fetch(`${state.config.supabaseUrl}/auth/v1/magiclink`, {
       method: "POST",
       headers: { "Content-Type": "application/json", apikey: state.config.supabaseAnonKey },
@@ -432,12 +433,12 @@ async function handleGoogleSignIn() {
     return;
   }
 
-  const redirectTo = `${state.config.appUrl}/auth/callback`;
+  const redirectTo = chrome.runtime.getURL(SIGNIN_CALLBACK_PATH);
   const googleOAuthUrl =
     `${state.config.supabaseUrl}/auth/v1/authorize?provider=google` +
     `&redirect_to=${encodeURIComponent(redirectTo)}`;
 
-  // Open OAuth in a new tab — user will be redirected back to appUrl/auth/callback
+  // Open OAuth in a new tab — user will be redirected back to extension callback page
   chrome.tabs.create({ url: googleOAuthUrl });
   setStatus("Google sign-in opened in new tab…");
   hideModal(authModalEl);

--- a/event-attendee-extension/signin-callback.css
+++ b/event-attendee-extension/signin-callback.css
@@ -1,0 +1,125 @@
+:root {
+  --bg: #f3f2ef;
+  --surface: #ffffff;
+  --border: #dce6f1;
+  --text: #1d2226;
+  --muted: #5f6b7a;
+  --ok-bg: #e7f6ef;
+  --ok-border: #b9e3cf;
+  --ok-text: #0d6f3f;
+  --err-bg: #fdf0ef;
+  --err-border: #f5c6c2;
+  --err-text: #b42318;
+  --info-bg: #eef5ff;
+  --info-border: #c9dbf5;
+  --info-text: #0a66c2;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.callback-wrap {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.callback-card {
+  width: min(520px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 8px 26px rgba(15, 23, 42, 0.08);
+}
+
+h1 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+#statusMessage {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.status-container {
+  margin-top: 14px;
+}
+
+.status-box {
+  border: 1px solid;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.status-box.success {
+  background: var(--ok-bg);
+  border-color: var(--ok-border);
+  color: var(--ok-text);
+}
+
+.status-box.error {
+  background: var(--err-bg);
+  border-color: var(--err-border);
+  color: var(--err-text);
+}
+
+.status-box.info {
+  background: var(--info-bg);
+  border-color: var(--info-border);
+  color: var(--info-text);
+}
+
+.status-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.status-message {
+  line-height: 1.4;
+}
+
+.debug-info {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.9;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid #e5e7eb;
+  border-top-color: #0a66c2;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 12px;
+}
+
+.close-btn {
+  margin-top: 14px;
+  border: 1px solid #b7c9dd;
+  background: #ffffff;
+  color: #0a66c2;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  display: none;
+}
+
+.close-btn:hover {
+  background: #eef5ff;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/event-attendee-extension/signin-callback.html
+++ b/event-attendee-extension/signin-callback.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Prospect In — Sign-in callback</title>
+  <link rel="stylesheet" href="signin-callback.css" />
+</head>
+<body>
+  <main class="callback-wrap">
+    <section class="callback-card" aria-live="polite">
+      <div id="spinner" class="spinner" aria-hidden="true"></div>
+      <h1 id="statusTitle">Completing sign-in…</h1>
+      <p id="statusMessage">Please wait while we securely save your session in the extension.</p>
+      <div id="statusContainer" class="status-container"></div>
+      <button id="closeBtn" class="close-btn" type="button">Close tab</button>
+    </section>
+  </main>
+
+  <script src="signin-callback.js"></script>
+</body>
+</html>

--- a/event-attendee-extension/signin-callback.js
+++ b/event-attendee-extension/signin-callback.js
@@ -1,0 +1,154 @@
+const __cbNoopLogger = { log() {}, warn() {}, error() {} };
+
+const statusTitle = document.getElementById("statusTitle");
+const statusMessage = document.getElementById("statusMessage");
+const statusContainer = document.getElementById("statusContainer");
+const spinner = document.getElementById("spinner");
+const closeBtn = document.getElementById("closeBtn");
+
+closeBtn.addEventListener("click", () => window.close());
+
+function showStatus(type, title, message, debugInfo = null) {
+  const box = document.createElement("div");
+  box.className = `status-box ${type}`;
+  box.innerHTML = `
+    <div class="status-title">${escapeHtml(title)}</div>
+    <div class="status-message">${escapeHtml(message)}</div>
+    ${debugInfo ? `<div class="debug-info">${debugInfo}</div>` : ""}
+  `;
+
+  statusContainer.innerHTML = "";
+  statusContainer.appendChild(box);
+
+  if (type === "error") {
+    closeBtn.style.display = "inline-block";
+  }
+}
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function decodeJwtPayload(accessToken) {
+  const tokenParts = accessToken.split(".");
+  if (tokenParts.length !== 3) {
+    throw new Error("Invalid access token format received from Supabase.");
+  }
+
+  const base64Payload = tokenParts[1].replace(/-/g, "+").replace(/_/g, "/");
+  const paddedPayload = base64Payload + "=".repeat((4 - (base64Payload.length % 4)) % 4);
+
+  const jsonPayload = atob(paddedPayload);
+  return JSON.parse(jsonPayload);
+}
+
+function getCallbackParams() {
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const queryParams = new URLSearchParams(window.location.search);
+
+  return {
+    accessToken: hashParams.get("access_token") || queryParams.get("access_token") || "",
+    refreshToken: hashParams.get("refresh_token") || queryParams.get("refresh_token") || "",
+    expiresIn: hashParams.get("expires_in") || queryParams.get("expires_in") || "",
+    tokenType: hashParams.get("token_type") || queryParams.get("token_type") || "bearer",
+    errorCode: hashParams.get("error") || queryParams.get("error") || "",
+    errorDescription: hashParams.get("error_description") || queryParams.get("error_description") || "",
+  };
+}
+
+async function handleAuthCallback() {
+  try {
+    __cbNoopLogger.log("[signin-callback] starting auth callback handler");
+    __cbNoopLogger.log("[signin-callback] raw location", {
+      href: window.location.href,
+      search: window.location.search,
+      hash: window.location.hash,
+    });
+
+    const params = getCallbackParams();
+
+    if (params.errorCode || params.errorDescription) {
+      throw new Error(params.errorDescription || `Authentication error: ${params.errorCode}`);
+    }
+
+    if (!params.accessToken) {
+      throw new Error("No authentication data found in callback URL. The sign-in flow may have expired or been cancelled.");
+    }
+
+    const payload = decodeJwtPayload(params.accessToken);
+    const email = String(payload.email || payload.user_metadata?.email || "").trim();
+    const authProvider = String(payload.app_metadata?.provider || payload.user_metadata?.provider || "email").toLowerCase();
+    const expiresAt = payload.exp || Math.floor(Date.now() / 1000) + parseInt(params.expiresIn || "3600", 10);
+
+    if (!email) {
+      throw new Error("No email found in authentication token. Please try signing in again.");
+    }
+
+    const methodLabel = authProvider === "google" ? "Google" : "email link/code";
+    showStatus("info", "Saving session...", `Signed in via ${methodLabel} as ${email}. Saving to extension storage...`);
+
+    const response = await chrome.runtime.sendMessage({
+      type: "SUPABASE_AUTH_CALLBACK",
+      session: {
+        access_token: params.accessToken,
+        refresh_token: params.refreshToken,
+        expires_at: expiresAt,
+        token_type: params.tokenType,
+        user: {
+          id: payload.sub || payload.user_id || "",
+          email,
+        },
+      },
+    });
+
+    if (!response) {
+      throw new Error("No response from extension background script. Please reload the extension and try again.");
+    }
+
+    if (!response.success) {
+      throw new Error(response.error || "Failed to store authentication session in extension.");
+    }
+
+    spinner.style.display = "none";
+    statusTitle.textContent = "Signed in successfully! ✓";
+    statusMessage.textContent = `Welcome back, ${email}`;
+
+    const expiresDate = new Date(expiresAt * 1000).toLocaleString();
+    showStatus(
+      "success",
+      "Authentication complete",
+      "You can close this tab now. Your Prospect In extension is now signed in and ready to use.",
+      `Method: ${escapeHtml(methodLabel)}<br>Email: ${escapeHtml(email)}<br>Session expires: ${escapeHtml(expiresDate)}`,
+    );
+
+    try {
+      await chrome.runtime.sendMessage({
+        type: "AUTH_SUCCESS_CALLBACK",
+        email,
+      });
+    } catch (err) {
+      __cbNoopLogger.warn("[signin-callback] could not trigger auth success callback", err);
+    }
+
+    setTimeout(() => {
+      window.close();
+    }, 2500);
+  } catch (error) {
+    __cbNoopLogger.error("[signin-callback] authentication failed:", error);
+
+    spinner.style.display = "none";
+    statusTitle.textContent = "Authentication failed";
+    statusMessage.textContent = "Something went wrong during sign-in.";
+
+    showStatus(
+      "error",
+      "Error",
+      error.message,
+      `Error type: ${escapeHtml(error.name)}<br>Please close this tab and try again from the extension side panel.`,
+    );
+  }
+}
+
+document.addEventListener("DOMContentLoaded", handleAuthCallback);


### PR DESCRIPTION
### Motivation

- Prevent OAuth/magic-link dead-ends by handling Supabase callback tokens inside the extension instead of redirecting back to the external web app.
- Persist and normalize Supabase sessions into extension storage so the sidepanel can immediately reflect signed-in state and resume flows like exports.

### Description

- Added a dedicated extension callback UI and handler: `signin-callback.html`, `signin-callback.js`, and `signin-callback.css` which parse tokens, decode the JWT payload, send the session to the background script, and show success/error UI with auto-close behavior.
- Updated `sidepanel.js` to redirect both magic-link and Google OAuth flows to `chrome.runtime.getURL("signin-callback.html")` so the extension receives callback tokens directly.
- Extended `background.js` with message handling for `SUPABASE_AUTH_CALLBACK` and `AUTH_SUCCESS_CALLBACK` and implemented `storeSupabaseSession` and `fetchSupabaseUser` to validate/normalize and persist sessions in `chrome.storage.local`.
- Fixed the default Supabase URL typo in `background.js` to match the sidepanel default and ensure consistent configuration.

### Testing

- Ran `node --check event-attendee-extension/sidepanel.js` which succeeded.
- Ran `node --check event-attendee-extension/background.js` which succeeded.
- Ran `node --check event-attendee-extension/signin-callback.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df899ca7d8832b9e58a1890b69531d)