### PR TITLE
Make signin callback web-accessible and add auth debug logs

### DIFF
--- a/event-attendee-extension/manifest.json
+++ b/event-attendee-extension/manifest.json
@@ -42,6 +42,18 @@
       ],
       "run_at": "document_idle"
     }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "signin-callback.html",
+        "signin-callback.js",
+        "signin-callback.css"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
   ]
 
   

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -375,6 +375,7 @@ async function handleMagicLink() {
 
   try {
     const redirectTo = chrome.runtime.getURL(SIGNIN_CALLBACK_PATH);
+    console.log("[sidepanel] magic link redirect target", { redirectTo, email });
     const res = await fetch(`${state.config.supabaseUrl}/auth/v1/magiclink`, {
       method: "POST",
       headers: { "Content-Type": "application/json", apikey: state.config.supabaseAnonKey },
@@ -409,6 +410,10 @@ async function handleGoogleSignIn() {
   const googleOAuthUrl =
     `${state.config.supabaseUrl}/auth/v1/authorize?provider=google` +
     `&redirect_to=${encodeURIComponent(redirectTo)}`;
+  console.log("[sidepanel] google oauth flow start", {
+    redirectTo,
+    googleOAuthUrl,
+  });
 
   // Open OAuth in a new tab — user will be redirected back to extension callback page
   chrome.tabs.create({ url: googleOAuthUrl });


### PR DESCRIPTION
### Motivation
- Supabase/Google redirects back to `signin-callback.html` were being blocked when navigating into the extension, resulting in `ERR_BLOCKED_BY_CLIENT` and failed sign-in flows. 
- Making the callback assets accessible and adding targeted logs helps ensure third-party redirects can reach the extension and makes the redirect flow easier to debug.

### Description
- Added `web_accessible_resources` entries to `event-attendee-extension/manifest.json` for `signin-callback.html`, `signin-callback.js`, and `signin-callback.css` so third-party redirects can load the extension callback page. 
- Added debug `console.log` statements in `event-attendee-extension/sidepanel.js` to print the generated `redirectTo` URL and the Google OAuth URL when starting magic-link and Google sign-in flows. 
- No other behavior or UI logic was changed.

### Testing
- Validated `manifest.json` is well-formed JSON using `python -m json.tool event-attendee-extension/manifest.json`, which succeeded. 
- Inspected the repository diff with `git diff` and confirmed only the manifest and `sidepanel.js` log additions were changed. 
- Committed the changes to the branch and confirmed the working tree contains the two modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a986b360832bb1e8933c3fac3274)