### PR TITLE
Fix signed-in header badge visibility in side panel

### DIFF
--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -587,11 +587,15 @@ function syncAccountUI() {
   ensureSessionUserShape();
   const email = state.profile?.email || state.session?.user?.email;
   const signedOutBadge = $("signedOutBadge");
- 
+
   if (email) {
     // Signed in
     accountBadgeEl.hidden = false;
-    if (signedOutBadge) signedOutBadge.hidden = true;
+    accountBadgeEl.style.display = "flex";
+    if (signedOutBadge) {
+      signedOutBadge.hidden = true;
+      signedOutBadge.style.display = "none";
+    }
     accountEmailEl.textContent = email;
     accountCreditsEl.textContent = state.hasUnlimited
       ? "∞ credits"
@@ -599,13 +603,17 @@ function syncAccountUI() {
   } else {
     // Signed out
     accountBadgeEl.hidden = true;
-    if (signedOutBadge) signedOutBadge.hidden = false;
+    accountBadgeEl.style.display = "none";
+    if (signedOutBadge) {
+      signedOutBadge.hidden = false;
+      signedOutBadge.style.display = "flex";
+    }
     accountEmailEl.textContent = "";
     accountCreditsEl.textContent = "";
     setStatus("Sign in to unlock full exports.");
   }
 }
- 
+
 
 function setViewMode(mode) {
   state.viewMode = mode;


### PR DESCRIPTION
### Motivation
- The header still showed the signed-out row (`Not signed in` / `Sign in`) when a user was authenticated, so the UI should hide the signed-out badge whenever an authenticated email is present.

### Description
- Updated `syncAccountUI()` in `event-attendee-extension/sidepanel.js` to explicitly toggle both the `hidden` property and `style.display` for the signed-in (`accountBadge`) and signed-out (`signedOutBadge`) header badges so the correct row is reliably visible.

### Testing
- Ran `node --check event-attendee-extension/sidepanel.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0bd48c2f8832b9f302d9f2e548a2e)