### PR TITLE
Add Export History tab and prevent credits on canceled downloads

### DIFF
--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -138,6 +138,34 @@ body {
   overflow: hidden;
   box-shadow: var(--shadow);
 }
+.panel-tabs {
+  display: flex;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: 4px;
+  box-shadow: var(--shadow);
+  gap: 4px;
+}
+.panel-tab-btn {
+  flex: 1;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 11.5px;
+  font-weight: 700;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.panel-tab-btn.active {
+  background: var(--blue-soft);
+  color: var(--blue-hover);
+}
+.panel-tab-btn:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+}
 .results-header {
   display: flex;
   justify-content: space-between;
@@ -180,10 +208,24 @@ body {
 
 /* ── History ── */
 .history-list { display: flex; flex-direction: column; max-height: 200px; overflow-y: auto; }
-.history-item { padding: 9px 12px; border-bottom: 1px solid var(--border-subtle); font-size: 11.5px; display: flex; justify-content: space-between; align-items: center; }
+.history-item { padding: 9px 12px; border-bottom: 1px solid var(--border-subtle); font-size: 11.5px; display: grid; grid-template-columns: 1.2fr 1.5fr 1fr .7fr auto; gap: 8px; align-items: center; }
 .history-item:last-child { border-bottom: none; }
 .history-meta { color: var(--text-2); font-size: 10.5px; margin-top: 2px; }
 .history-dl { color: var(--blue); font-size: 10.5px; cursor: pointer; background: none; border: none; font-weight: 600; }
+.history-head {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-muted);
+  color: var(--text-2);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+  display: grid;
+  grid-template-columns: 1.2fr 1.5fr 1fr .7fr auto;
+  gap: 8px;
+}
+.history-cell { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ── Empty ── */
 .empty { padding: 24px 14px; text-align: center; color: var(--text-muted); font-size: 11.5px; line-height: 1.7; }

--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -57,7 +57,12 @@
   </section>
 
   <!-- Attendee list -->
-  <section class="results">
+  <section class="panel-tabs">
+    <button id="attendeesTabBtn" class="panel-tab-btn active" type="button">Attendees</button>
+    <button id="historyTabBtn" class="panel-tab-btn" type="button">History</button>
+  </section>
+
+  <section id="attendeesSection" class="results">
     <div class="results-header">
       <h2>Attendee List</h2>
       <div class="results-header-right">

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -17,6 +17,7 @@ const state = {
   pollTimer: null,
   pendingExportFormat: null,
   exportInProgress: false,
+  activeTab: "attendees",
   config: {
     supabaseUrl: DEFAULT_SUPABASE_URL,
     supabaseAnonKey: "",
@@ -28,6 +29,7 @@ const state = {
 const $ = (id) => document.getElementById(id);
 const statusEl = $("statusText");
 const attendeeListEl = $("attendeeList");
+const attendeesSectionEl = $("attendeesSection");
 const countBadgeEl = $("countBadge");
 const crmSelectEl = $("crmSelect");
 const accountBadgeEl = $("accountBadge");
@@ -58,6 +60,8 @@ $("saveJsonBtn").addEventListener("click", handleSaveJson);
 $("detailedViewBtn").addEventListener("click", () => setViewMode("detailed"));
 $("cardViewBtn").addEventListener("click", () => setViewMode("card"));
 $("signOutBtn").addEventListener("click", handleSignOut);
+$("attendeesTabBtn").addEventListener("click", () => setActivePanelTab("attendees"));
+$("historyTabBtn").addEventListener("click", () => setActivePanelTab("history"));
 $("signInBtn").addEventListener("click", handleSignIn);
 $("magicLinkBtn").addEventListener("click", handleMagicLink);
 $("googleSignInBtn").addEventListener("click", handleGoogleSignIn);
@@ -133,6 +137,7 @@ async function init() {
   limitInputEl.value = state.attendeeLimit;
   syncViewModeUI();
   syncAccountUI();
+  setActivePanelTab("attendees");
   renderHistory(s.exportHistory ?? []);
   $("openWebAppLink").href = state.config.appUrl;
 
@@ -217,7 +222,7 @@ function openExportModal(format) {
   showModal(exportModalEl);
 }
 
-function doExport(fullReport) {
+async function doExport(fullReport) {
   if (state.exportInProgress) {
     console.log("[sidepanel] export blocked: already in progress", { fullReport });
     return;
@@ -231,16 +236,30 @@ function doExport(fullReport) {
   const crm = crmSelectEl.value;
   const label = (window.CRM_PROFILES?.[crm] ?? window.CRM_PROFILES?.generic)?.label ?? crm;
 
+  const filename = fmt === "csv" ? `attendees-${crm}-${today()}.csv` : `attendees-${today()}.pdf`;
+  let downloadResult;
+
   if (fmt === "csv") {
     const csv = window.buildCrmCsv(attendees, crm);
-    downloadBlob(csv, "text/csv;charset=utf-8", `attendees-${crm}-${today()}.csv`);
+    downloadResult = await downloadBlob(csv, "text/csv;charset=utf-8", filename);
   } else {
     const bytes = buildSimplePdf(attendees);
-    downloadBlob(
+    downloadResult = await downloadBlob(
       new Blob([bytes], { type: "application/pdf" }),
       "application/pdf",
-      `attendees-${today()}.pdf`,
+      filename,
     );
+  }
+
+  if (!downloadResult.ok) {
+    console.log("[sidepanel] export canceled or failed", {
+      fullReport,
+      filename,
+      reason: downloadResult.error,
+    });
+    setStatus(downloadResult.canceled ? "Download canceled — no credit charged." : "Download failed. No credit charged.");
+    state.exportInProgress = false;
+    return;
   }
 
   if (usedCredit) {
@@ -254,13 +273,11 @@ function doExport(fullReport) {
     deductCreditInDB();
   }
 
-  if (state.session && fullReport) saveToHistory(attendees.length, fmt, crm);
+  if (state.session && fullReport) await saveToHistory(attendees, fmt, crm, filename);
 
   const truncNote = !fullReport && state.attendees.length > FREE_LIMIT ? ` (first ${FREE_LIMIT})` : "";
   setStatus(`Exported ${attendees.length} attendees for ${label}${truncNote}.`);
-  setTimeout(() => {
-    state.exportInProgress = false;
-  }, 300);
+  state.exportInProgress = false;
 }
 
 // ── JSON save — free limit unless signed in ────────────────────────────────
@@ -280,22 +297,46 @@ function handleSaveJson() {
 }
 
 // ── History ───────────────────────────────────────────────────────────────────
-async function saveToHistory(count, fmt, crm) {
+async function saveToHistory(attendees, fmt, crm, filename) {
   const s = await chrome.storage.local.get("exportHistory");
   const history = s.exportHistory ?? [];
-  history.unshift({ count, fmt, crm, date: new Date().toISOString() });
+  history.unshift({
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    attendees,
+    rowCount: attendees.length,
+    fmt,
+    crm,
+    filename,
+    date: new Date().toISOString(),
+  });
   const trimmed = history.slice(0, 30);
   chrome.storage.local.set({ exportHistory: trimmed });
   renderHistory(trimmed);
 }
 
 function renderHistory(history) {
-  if (!state.session || !history.length) {
+  if (!state.session) {
     historySectionEl.hidden = true;
     return;
   }
-  historySectionEl.hidden = false;
+  historySectionEl.hidden = state.activeTab !== "history";
   historyListEl.innerHTML = "";
+  if (!history.length) {
+    historyListEl.innerHTML = `<div class="empty"><div class="empty-icon">🧾</div>No purchased reports yet.</div>`;
+    return;
+  }
+
+  const head = document.createElement("div");
+  head.className = "history-head";
+  head.innerHTML = `
+    <div>Date</div>
+    <div>Name</div>
+    <div>CRM Target</div>
+    <div>Rows</div>
+    <div></div>
+  `;
+  historyListEl.appendChild(head);
+
   history.forEach((item) => {
     const div = document.createElement("div");
     div.className = "history-item";
@@ -304,14 +345,49 @@ function renderHistory(history) {
       d.toLocaleDateString("sv-SE") +
       " " +
       d.toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
+    const rowCount = item.rowCount ?? item.count ?? (Array.isArray(item.attendees) ? item.attendees.length : 0);
+    const filename = item.filename || `attendees-${item.crm ?? "generic"}-${item.date?.slice(0, 10) || today()}.${item.fmt || "csv"}`;
     div.innerHTML = `
-      <div>
-        <div>${item.count} attendees · ${item.fmt?.toUpperCase()} · ${item.crm ?? "generic"}</div>
-        <div class="history-meta">${dateStr}</div>
-      </div>
+      <div class="history-cell history-meta">${dateStr}</div>
+      <div class="history-cell">${esc(filename)}</div>
+      <div class="history-cell">${esc(item.crm ?? "generic")}</div>
+      <div class="history-cell">${rowCount}</div>
+      <button class="history-dl">Redownload</button>
     `;
+    const downloadBtn = div.querySelector(".history-dl");
+    downloadBtn.addEventListener("click", () => redownloadFromHistory(item));
     historyListEl.appendChild(div);
   });
+}
+
+async function redownloadFromHistory(item) {
+  const attendees = Array.isArray(item.attendees) ? item.attendees : [];
+  if (!attendees.length) {
+    setStatus("Cannot redownload this report — stored data is missing.");
+    return;
+  }
+
+  console.log("[sidepanel] redownload history item", {
+    date: item.date,
+    filename: item.filename,
+    crm: item.crm,
+    rows: attendees.length,
+  });
+
+  let result;
+  if (item.fmt === "csv") {
+    const csv = window.buildCrmCsv(attendees, item.crm || "generic");
+    result = await downloadBlob(csv, "text/csv;charset=utf-8", item.filename || `attendees-${item.crm || "generic"}-${today()}.csv`);
+  } else {
+    const bytes = buildSimplePdf(attendees);
+    result = await downloadBlob(new Blob([bytes], { type: "application/pdf" }), "application/pdf", item.filename || `attendees-${today()}.pdf`);
+  }
+
+  if (!result.ok) {
+    setStatus(result.canceled ? "Redownload canceled." : "Redownload failed.");
+    return;
+  }
+  setStatus(`Redownloaded ${attendees.length} rows from history.`);
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -625,6 +701,27 @@ function syncAccountUI() {
     accountCreditsEl.textContent = "";
     setStatus("Sign in to unlock full exports.");
   }
+  syncHistoryTabVisibility();
+}
+
+function setActivePanelTab(tab) {
+  state.activeTab = tab === "history" ? "history" : "attendees";
+  $("attendeesTabBtn").classList.toggle("active", state.activeTab === "attendees");
+  $("historyTabBtn").classList.toggle("active", state.activeTab === "history");
+  const showHistory = Boolean(state.session) && state.activeTab === "history";
+  historySectionEl.hidden = !showHistory;
+  attendeesSectionEl.hidden = state.activeTab !== "attendees";
+  if (showHistory) {
+    chrome.storage.local.get("exportHistory").then((s) => renderHistory(s.exportHistory ?? []));
+  }
+}
+
+function syncHistoryTabVisibility() {
+  const hasAccessToHistory = Boolean(state.session);
+  $("historyTabBtn").disabled = !hasAccessToHistory;
+  if (!hasAccessToHistory && state.activeTab === "history") {
+    setActivePanelTab("attendees");
+  }
 }
 
 
@@ -664,9 +761,17 @@ function today() {
 function downloadBlob(data, mime, filename) {
   const blob = data instanceof Blob ? data : new Blob([data], { type: mime });
   const url = URL.createObjectURL(blob);
-  chrome.downloads.download({ url, filename, saveAs: true }, () =>
-    setTimeout(() => URL.revokeObjectURL(url), 1000),
-  );
+  return new Promise((resolve) => {
+    chrome.downloads.download({ url, filename, saveAs: true }, (downloadId) => {
+      const err = chrome.runtime.lastError?.message;
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      if (err) {
+        resolve({ ok: false, canceled: /canceled/i.test(err), error: err });
+        return;
+      }
+      resolve({ ok: Number.isInteger(downloadId), canceled: false, error: null, downloadId });
+    });
+  });
 }
 
 function esc(v) {


### PR DESCRIPTION
### Motivation
- Provide a history of purchased exports so users can re-download previously purchased reports without being charged again.
- Fix an issue where pressing Download then canceling still deducted a credit; downloads should only consume credits when a download actually starts.

### Description
- Added a top-level tab switcher and an attendees panel ID to toggle between `Attendees` and `History` views, plus CSS for tab styling. (`sidepanel.html`, `sidepanel.css`).
- Implemented a richer export history persistence format that stores report payload + metadata (`id`, `attendees`, `rowCount`, `fmt`, `crm`, `filename`, `date`) and renders columns: Date, Name, CRM target, Rows, and a `Redownload` button. (`sidepanel.js`, `sidepanel.css`).
- Implemented `redownloadFromHistory` which re-generates CSV/PDF from stored payload and downloads it without deducting credits.
- Changed export flow to await `chrome.downloads.download` via a new `downloadBlob` promise wrapper and only deduct credits after a successful download start; canceled/failed downloads do not deduct credits and set a clear status message. (`sidepanel.js`).
- Gate history access to signed-in users and added tab enable/disable logic so history is only available when authenticated. (`sidepanel.js`).

### Testing
- Ran a JavaScript syntax check: `node --check event-attendee-extension/sidepanel.js` and it succeeded.
- No automated UI or integration tests were run in this environment; manual behavior covered by the new download result handling path is exercised by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c8cf5b80832bbd00fe37661cbdf9)