### PR TITLE
Improve history layout and add redownload format selector

### DIFF
--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -208,7 +208,7 @@ body {
 
 /* ── History ── */
 .history-list { display: flex; flex-direction: column; max-height: 200px; overflow-y: auto; }
-.history-item { padding: 9px 12px; border-bottom: 1px solid var(--border-subtle); font-size: 11.5px; display: grid; grid-template-columns: 1.2fr 1.5fr 1fr .7fr auto; gap: 8px; align-items: center; }
+.history-item { padding: 9px 12px; border-bottom: 1px solid var(--border-subtle); font-size: 11.5px; display: grid; gap: 8px; }
 .history-item:last-child { border-bottom: none; }
 .history-meta { color: var(--text-2); font-size: 10.5px; margin-top: 2px; }
 .history-dl { color: var(--blue); font-size: 10.5px; cursor: pointer; background: none; border: none; font-weight: 600; }
@@ -222,10 +222,44 @@ body {
   text-transform: uppercase;
   letter-spacing: .3px;
   display: grid;
-  grid-template-columns: 1.2fr 1.5fr 1fr .7fr auto;
+  grid-template-columns: 1.8fr 1fr .7fr auto;
   gap: 8px;
+  text-align: left;
 }
 .history-cell { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.history-item {
+  grid-template-columns: 1.8fr 1fr .7fr auto;
+  align-items: start;
+  text-align: left;
+}
+.history-date-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.history-name {
+  font-size: 10.5px;
+  color: var(--text-2);
+}
+.history-redownload {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.history-format-select {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 20px 4px 7px;
+  font-size: 10.5px;
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+  background: var(--surface);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%235f6b7a' stroke-width='1.3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+}
 
 /* ── Empty ── */
 .empty { padding: 24px 14px; text-align: center; color: var(--text-muted); font-size: 11.5px; line-height: 1.7; }

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -329,8 +329,7 @@ function renderHistory(history) {
   const head = document.createElement("div");
   head.className = "history-head";
   head.innerHTML = `
-    <div>Date</div>
-    <div>Name</div>
+    <div>Date / Name</div>
     <div>CRM Target</div>
     <div>Rows</div>
     <div></div>
@@ -347,20 +346,31 @@ function renderHistory(history) {
       d.toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
     const rowCount = item.rowCount ?? item.count ?? (Array.isArray(item.attendees) ? item.attendees.length : 0);
     const filename = item.filename || `attendees-${item.crm ?? "generic"}-${item.date?.slice(0, 10) || today()}.${item.fmt || "csv"}`;
+    const originalFormat = item.fmt || "csv";
     div.innerHTML = `
-      <div class="history-cell history-meta">${dateStr}</div>
-      <div class="history-cell">${esc(filename)}</div>
+      <div class="history-cell history-date-wrap">
+        <span class="history-meta">${dateStr}</span>
+        <span class="history-name">${esc(filename)}</span>
+      </div>
       <div class="history-cell">${esc(item.crm ?? "generic")}</div>
       <div class="history-cell">${rowCount}</div>
-      <button class="history-dl">Redownload</button>
+      <div class="history-redownload">
+        <select class="history-format-select" aria-label="Select redownload format">
+          <option value="csv"${originalFormat === "csv" ? " selected" : ""}>CSV</option>
+          <option value="json"${originalFormat === "json" ? " selected" : ""}>JSON</option>
+          <option value="pdf"${originalFormat === "pdf" ? " selected" : ""}>PDF</option>
+        </select>
+        <button class="history-dl">Redownload</button>
+      </div>
     `;
+    const formatSelect = div.querySelector(".history-format-select");
     const downloadBtn = div.querySelector(".history-dl");
-    downloadBtn.addEventListener("click", () => redownloadFromHistory(item));
+    downloadBtn.addEventListener("click", () => redownloadFromHistory(item, formatSelect.value));
     historyListEl.appendChild(div);
   });
 }
 
-async function redownloadFromHistory(item) {
+async function redownloadFromHistory(item, format) {
   const attendees = Array.isArray(item.attendees) ? item.attendees : [];
   if (!attendees.length) {
     setStatus("Cannot redownload this report — stored data is missing.");
@@ -372,22 +382,26 @@ async function redownloadFromHistory(item) {
     filename: item.filename,
     crm: item.crm,
     rows: attendees.length,
+    format,
   });
 
   let result;
-  if (item.fmt === "csv") {
+  if (format === "csv") {
     const csv = window.buildCrmCsv(attendees, item.crm || "generic");
-    result = await downloadBlob(csv, "text/csv;charset=utf-8", item.filename || `attendees-${item.crm || "generic"}-${today()}.csv`);
+    result = await downloadBlob(csv, "text/csv;charset=utf-8", `attendees-${item.crm || "generic"}-${today()}.csv`);
+  } else if (format === "json") {
+    const json = JSON.stringify(attendees, null, 2);
+    result = await downloadBlob(json, "application/json", `attendees-${item.crm || "generic"}-${today()}.json`);
   } else {
     const bytes = buildSimplePdf(attendees);
-    result = await downloadBlob(new Blob([bytes], { type: "application/pdf" }), "application/pdf", item.filename || `attendees-${today()}.pdf`);
+    result = await downloadBlob(new Blob([bytes], { type: "application/pdf" }), "application/pdf", `attendees-${item.crm || "generic"}-${today()}.pdf`);
   }
 
   if (!result.ok) {
     setStatus(result.canceled ? "Redownload canceled." : "Redownload failed.");
     return;
   }
-  setStatus(`Redownloaded ${attendees.length} rows from history.`);
+  setStatus(`Redownloaded ${attendees.length} rows as ${format.toUpperCase()}.`);
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Reduce visual crowding in the Export History rows by placing the exported file name on its own line under the date. 
- Left-align history headers and values so the `CRM Target` header lines up with its values. 
- Allow users to re-download a saved report in any supported format (CSV/JSON/PDF) without re-exporting from the event page.

### Description
- Updated history list layout and alignment in `event-attendee-extension/sidepanel.css`, adding `.history-date-wrap`, `.history-name`, `.history-redownload`, and `.history-format-select`, and left-aligning the header row. 
- Simplified `.history-item` grid and adjusted `history-head` column widths so `CRM Target` lines up with its column. 
- Modified `renderHistory` in `event-attendee-extension/sidepanel.js` to show `Date / Name` in the header and render filename on a second line under the date for each row. 
- Added a per-row format dropdown (CSV / JSON / PDF) and updated `redownloadFromHistory` to accept a `format` parameter and produce format-specific downloads (using `window.buildCrmCsv`, JSON serialization, or `buildSimplePdf`) and consistent filenames, and to update the status message to reflect the chosen format.

### Testing
- Ran `node --check event-attendee-extension/sidepanel.js` and it completed successfully. 
- No other automated tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ccdda78c832b99fe16b709922f63)