### PR TITLE
Align history columns and enable redownload to a different CRM target

### DIFF
--- a/event-attendee-extension/sidepanel.css
+++ b/event-attendee-extension/sidepanel.css
@@ -222,14 +222,14 @@ body {
   text-transform: uppercase;
   letter-spacing: .3px;
   display: grid;
-  grid-template-columns: 1.8fr 1fr .7fr auto;
+  grid-template-columns: minmax(170px, 1.8fr) minmax(84px, 1fr) minmax(46px, .7fr) minmax(190px, auto);
   gap: 8px;
   text-align: left;
 }
 .history-cell { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .history-item {
-  grid-template-columns: 1.8fr 1fr .7fr auto;
-  align-items: start;
+  grid-template-columns: minmax(170px, 1.8fr) minmax(84px, 1fr) minmax(46px, .7fr) minmax(190px, auto);
+  align-items: center;
   text-align: left;
 }
 .history-date-wrap {
@@ -246,6 +246,21 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  justify-content: flex-start;
+}
+.history-crm-select {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 20px 4px 7px;
+  font-size: 10.5px;
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+  background: var(--surface);
+  appearance: none;
+  max-width: 92px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%235f6b7a' stroke-width='1.3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
 }
 .history-format-select {
   border: 1px solid var(--border);
@@ -259,6 +274,7 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%235f6b7a' stroke-width='1.3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 6px center;
+  min-width: 60px;
 }
 
 /* ── Empty ── */

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -332,7 +332,7 @@ function renderHistory(history) {
     <div>Date / Name</div>
     <div>CRM Target</div>
     <div>Rows</div>
-    <div></div>
+    <div>Redownload</div>
   `;
   historyListEl.appendChild(head);
 
@@ -347,6 +347,10 @@ function renderHistory(history) {
     const rowCount = item.rowCount ?? item.count ?? (Array.isArray(item.attendees) ? item.attendees.length : 0);
     const filename = item.filename || `attendees-${item.crm ?? "generic"}-${item.date?.slice(0, 10) || today()}.${item.fmt || "csv"}`;
     const originalFormat = item.fmt || "csv";
+    const originalCrm = item.crm || "generic";
+    const crmOptions = Object.entries(window.CRM_PROFILES || {})
+      .map(([key, profile]) => `<option value="${esc(key)}"${key === originalCrm ? " selected" : ""}>${esc(profile.label || key)}</option>`)
+      .join("");
     div.innerHTML = `
       <div class="history-cell history-date-wrap">
         <span class="history-meta">${dateStr}</span>
@@ -355,6 +359,9 @@ function renderHistory(history) {
       <div class="history-cell">${esc(item.crm ?? "generic")}</div>
       <div class="history-cell">${rowCount}</div>
       <div class="history-redownload">
+        <select class="history-crm-select" aria-label="Select redownload CRM target">
+          ${crmOptions}
+        </select>
         <select class="history-format-select" aria-label="Select redownload format">
           <option value="csv"${originalFormat === "csv" ? " selected" : ""}>CSV</option>
           <option value="json"${originalFormat === "json" ? " selected" : ""}>JSON</option>
@@ -363,45 +370,49 @@ function renderHistory(history) {
         <button class="history-dl">Redownload</button>
       </div>
     `;
+    const crmSelect = div.querySelector(".history-crm-select");
     const formatSelect = div.querySelector(".history-format-select");
     const downloadBtn = div.querySelector(".history-dl");
-    downloadBtn.addEventListener("click", () => redownloadFromHistory(item, formatSelect.value));
+    downloadBtn.addEventListener("click", () => redownloadFromHistory(item, formatSelect.value, crmSelect.value));
     historyListEl.appendChild(div);
   });
 }
 
-async function redownloadFromHistory(item, format) {
+async function redownloadFromHistory(item, format, crmTarget) {
   const attendees = Array.isArray(item.attendees) ? item.attendees : [];
   if (!attendees.length) {
     setStatus("Cannot redownload this report — stored data is missing.");
     return;
   }
 
+  const selectedCrm = crmTarget || item.crm || "generic";
+
   console.log("[sidepanel] redownload history item", {
     date: item.date,
     filename: item.filename,
     crm: item.crm,
+    crmTarget: selectedCrm,
     rows: attendees.length,
     format,
   });
 
   let result;
   if (format === "csv") {
-    const csv = window.buildCrmCsv(attendees, item.crm || "generic");
-    result = await downloadBlob(csv, "text/csv;charset=utf-8", `attendees-${item.crm || "generic"}-${today()}.csv`);
+    const csv = window.buildCrmCsv(attendees, selectedCrm);
+    result = await downloadBlob(csv, "text/csv;charset=utf-8", `attendees-${selectedCrm}-${today()}.csv`);
   } else if (format === "json") {
     const json = JSON.stringify(attendees, null, 2);
-    result = await downloadBlob(json, "application/json", `attendees-${item.crm || "generic"}-${today()}.json`);
+    result = await downloadBlob(json, "application/json", `attendees-${selectedCrm}-${today()}.json`);
   } else {
     const bytes = buildSimplePdf(attendees);
-    result = await downloadBlob(new Blob([bytes], { type: "application/pdf" }), "application/pdf", `attendees-${item.crm || "generic"}-${today()}.pdf`);
+    result = await downloadBlob(new Blob([bytes], { type: "application/pdf" }), "application/pdf", `attendees-${selectedCrm}-${today()}.pdf`);
   }
 
   if (!result.ok) {
     setStatus(result.canceled ? "Redownload canceled." : "Redownload failed.");
     return;
   }
-  setStatus(`Redownloaded ${attendees.length} rows as ${format.toUpperCase()}.`);
+  setStatus(`Redownloaded ${attendees.length} rows as ${format.toUpperCase()} (${selectedCrm}).`);
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Fix misaligned history header and row cells so headings line up with values in the Export History table.  
- Allow users to redownload previously exported attendee data mapped to a different CRM target than the original export.

### Description
- Updated history header and row CSS to use matching `grid-template-columns` and improved vertical alignment for consistent column layout.  
- Added a per-row CRM selector (`.history-crm-select`) populated from `window.CRM_PROFILES` so users can choose a different CRM mapping when redownloading.  
- Extended `renderHistory` to render the CRM selector and changed the redownload button handler to pass the selected CRM.  
- Modified `redownloadFromHistory` to accept a `crmTarget`, use that for CSV mapping via `window.buildCrmCsv`, and include the selected CRM in filenames and status/log messages.

### Testing
- Ran `node --check event-attendee-extension/sidepanel.js` and it completed without syntax errors.  
- Verified the updated `renderHistory` and `redownloadFromHistory` logic by static inspection of the modified code paths (no runtime UI automation available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cef1f964832bac4dccdc719f342c)