### PR TITLE
Open welcome page on first install and forward Stripe coupon at checkout

### DIFF
--- a/event-attendee-extension/background.js
+++ b/event-attendee-extension/background.js
@@ -1,10 +1,16 @@
 
-chrome.runtime.onInstalled.addListener(() => {
+chrome.runtime.onInstalled.addListener((details) => {
   chrome.storage.local.set({
     supabaseAnonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZoZW1xZ2p3cWpxZ2pxcm5qaHZtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYxNTUyNDcsImV4cCI6MjA5MTczMTI0N30.Gyt1fxQgwM3_WFt6yEri-wRxvIg4m_z2TjjbwyzLOfI",
     supabaseUrl: "https://vhemqgjwqjqgjqrnjhvm.supabase.co",
     appUrl: "https://prospectin.vercel.app"
   });
+
+  if (details?.reason === "install") {
+    const welcomeUrl = chrome.runtime.getURL("welcome.html");
+    console.log("[Event Attendee Extractor] First install detected. Opening welcome page.", { welcomeUrl });
+    chrome.tabs.create({ url: welcomeUrl });
+  }
 });
 
 chrome.action.onClicked.addListener(async (tab) => {

--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -149,6 +149,10 @@
     <!-- Buy credits (shown when no credits) -->
     <div id="buyCreditsSection" class="buy-section" hidden>
       <p class="buy-title">Buy credits</p>
+      <div class="field-row">
+        <label for="stripeCouponInput" class="field-label">Stripe coupon code (optional)</label>
+        <input id="stripeCouponInput" class="input" type="text" placeholder="e.g. SPRING20" autocomplete="off" />
+      </div>
       <div class="pricing-grid">
         <button data-plan="single" class="pricing-btn">
           <strong>1 report</strong><span>$9.99</span>

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -51,6 +51,7 @@ const exportModalSubEl = $("exportModalSub");
 const exportTotalCountEl = $("exportTotalCount");
 const exportCreditDescEl = $("exportCreditDesc");
 const buyCreditsSection = $("buyCreditsSection");
+const stripeCouponInputEl = $("stripeCouponInput");
 
 // ── Wire up events ────────────────────────────────────────────────────────────
 $("scrapeBtn").addEventListener("click", handleScrape);
@@ -645,13 +646,16 @@ function stopPoll() {
 function handleBuy(plan) {
   ensureSessionUserShape();
   const url = new URL(`${state.config.appUrl}/checkout`);
+  const couponCode = stripeCouponInputEl?.value?.trim() || "";
   url.searchParams.set("plan", plan);
   url.searchParams.set("source", "extension");
   if (state.session?.user?.id) url.searchParams.set("user_id", state.session.user.id);
+  if (couponCode) url.searchParams.set("coupon", couponCode);
   console.log("[sidepanel] opening checkout", {
     url: url.toString(),
     userId: state.session?.user?.id || null,
     plan,
+    coupon: couponCode || null,
   });
   chrome.tabs.create({ url: url.toString() });
   setStatus("Opening checkout… credits sync automatically.");


### PR DESCRIPTION
### Motivation
- Ensure onboarding `welcome.html` is shown to users immediately after they install the extension so the onboarding flow actually triggers on first install.
- Allow customers to apply Stripe coupon codes from the extension checkout flow so discounts/promotions can be used at purchase.

### Description
- Update `background.js` to handle `chrome.runtime.onInstalled` with the `details` argument and open `welcome.html` when `details.reason === "install"`, plus a debug `console.log` for visibility.
- Add a coupon input field to the Buy Credits section in `sidepanel.html` (`#stripeCouponInput`).
- Wire the coupon value into the checkout URL in `sidepanel.js` by adding a `stripeCouponInputEl` reference and appending `coupon=<code>` to the `checkout` URL when present, and log the coupon in the debug output.

### Testing
- Ran `node --check event-attendee-extension/background.js` which succeeded.
- Ran `node --check event-attendee-extension/sidepanel.js` which succeeded.
- Validated `event-attendee-extension/manifest.json` with `python -m json.tool` which succeeded.
- Verified presence of relevant functions using `rg` which returned the expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ce678c14832b835e76a5f8d24ee7)