### PR TITLE
Move coupon handling from extension UI to Stripe Checkout

### DIFF
--- a/event-attendee-extension/sidepanel.html
+++ b/event-attendee-extension/sidepanel.html
@@ -149,10 +149,6 @@
     <!-- Buy credits (shown when no credits) -->
     <div id="buyCreditsSection" class="buy-section" hidden>
       <p class="buy-title">Buy credits</p>
-      <div class="field-row">
-        <label for="stripeCouponInput" class="field-label">Stripe coupon code (optional)</label>
-        <input id="stripeCouponInput" class="input" type="text" placeholder="e.g. SPRING20" autocomplete="off" />
-      </div>
       <div class="pricing-grid">
         <button data-plan="single" class="pricing-btn">
           <strong>1 report</strong><span>$9.99</span>

--- a/event-attendee-extension/sidepanel.js
+++ b/event-attendee-extension/sidepanel.js
@@ -51,7 +51,6 @@ const exportModalSubEl = $("exportModalSub");
 const exportTotalCountEl = $("exportTotalCount");
 const exportCreditDescEl = $("exportCreditDesc");
 const buyCreditsSection = $("buyCreditsSection");
-const stripeCouponInputEl = $("stripeCouponInput");
 
 // ── Wire up events ────────────────────────────────────────────────────────────
 $("scrapeBtn").addEventListener("click", handleScrape);
@@ -646,16 +645,13 @@ function stopPoll() {
 function handleBuy(plan) {
   ensureSessionUserShape();
   const url = new URL(`${state.config.appUrl}/checkout`);
-  const couponCode = stripeCouponInputEl?.value?.trim() || "";
   url.searchParams.set("plan", plan);
   url.searchParams.set("source", "extension");
   if (state.session?.user?.id) url.searchParams.set("user_id", state.session.user.id);
-  if (couponCode) url.searchParams.set("coupon", couponCode);
   console.log("[sidepanel] opening checkout", {
     url: url.toString(),
     userId: state.session?.user?.id || null,
     plan,
-    coupon: couponCode || null,
   });
   chrome.tabs.create({ url: url.toString() });
   setStatus("Opening checkout… credits sync automatically.");


### PR DESCRIPTION
### Motivation
- Shift coupon entry from the extension UI into Stripe Checkout so promotions are handled by the payment flow, and to enable adding `allow_promotion_codes: true` in the server-side `createCheckoutSession()` implementation.
- The repository snapshot does not contain the server/API file that implements `createCheckoutSession()`, so that server-side change could not be made here.

### Description
- Removed the coupon input markup from `event-attendee-extension/sidepanel.html` and the DOM reference `stripeCouponInput` from `event-attendee-extension/sidepanel.js`.
- Updated `handleBuy(plan)` to stop reading and appending a `coupon` query parameter while preserving `plan`, `source`, and optional `user_id` query params when opening the checkout URL.
- Left server-side `createCheckoutSession()` unchanged because the backend file was not found in this repo; `allow_promotion_codes: true` should be added there once the API file is available.

### Testing
- Ran `node --check event-attendee-extension/sidepanel.js` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d0690318832b965fb6d1ef9b8be7)